### PR TITLE
Connect: raise the default SDK floor to the 3.x line (0.15.0-0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed (BREAKING, Connect hosts) — the default SDK floor moves to the 3.x line
+
+`DEFAULT_MIN_CLIENT_SDK_VERSION` goes from `0.14.1-0` to **`0.15.0-0`**, so a wallet host refuses
+any dApp whose handshake reports an older `@unicitylabs/sphere-sdk` — or reports none — with
+`UNSUPPORTED_PROTOCOL_VERSION` (4007) naming the minimum.
+
+The Connect wire itself is still unchanged. What changed is underneath it: `sphere_getTokens`
+hands raw token CBOR across the wire, and a client on the 2.x SDK line cannot decode a 3.x token —
+it fails with `Unsupported Token version`. Such a dApp is already non-functional against a 0.15.x
+wallet, so this does not break anything that worked; it turns a cryptic decode failure deep inside
+the dApp into one legible refusal at the handshake.
+
+`-0` admits the whole `0.15.0` prerelease track, which is deliberate: those pin
+state-transition-sdk 3.x too, so they can decode what the wallet serves. The floor is about the
+SDK line, not about being a released version.
+
+Hosts that set `ConnectHostConfig.minSdkVersion` explicitly are unaffected. The claim remains
+compatibility hygiene rather than security — a hostile client can misreport its version.
 
 ## [0.15.0] - 2026-08-27
 

--- a/connect/protocol.ts
+++ b/connect/protocol.ts
@@ -12,12 +12,17 @@ import { majorOf } from './semver';
 export const SPHERE_CONNECT_NAMESPACE = 'sphere-connect';
 export const SPHERE_CONNECT_VERSION = '2.1';   // Connect protocol version (semver MAJOR.MINOR)
 
-// Default npm-SDK floor a host enforces at the handshake (0.14.1 = the P11 flip:
-// the v1 payments era is gone; pre-flip ConnectClients expect a wallet that no
-// longer exists). '-0' admits every 0.14.1 prerelease (compareSemver: release >
-// prerelease). Override via ConnectHostConfig.minSdkVersion; the claim is
-// compatibility hygiene, not security — a hostile client can lie about it.
-export const DEFAULT_MIN_CLIENT_SDK_VERSION = '0.14.1-0';
+// Default npm-SDK floor a host enforces at the handshake. 0.15.0 is the
+// state-transition-sdk 3.x line: the Connect WIRE did not change, but
+// `sphere_getTokens` hands raw token CBOR across it, and a client on the 2.x line
+// cannot decode a 3.x token — it fails with "Unsupported Token version". Such a
+// client is already non-functional against this wallet, so the floor turns a
+// cryptic decode failure deep in the dApp into one legible refusal at the
+// handshake. '-0' admits every 0.15.0 prerelease (compareSemver: release >
+// prerelease), which is what we want: those pin the 3.x SDK too.
+// Override via ConnectHostConfig.minSdkVersion; the claim is compatibility
+// hygiene, not security — a hostile client can lie about it.
+export const DEFAULT_MIN_CLIENT_SDK_VERSION = '0.15.0-0';
 
 export { HOST_READY_TYPE, HOST_READY_TIMEOUT, SPHERE_NETWORKS } from '../constants';
 // Import for local use (e.g. SphereHandshake.network) AND re-export for connect consumers.

--- a/connect/protocol.ts
+++ b/connect/protocol.ts
@@ -12,16 +12,11 @@ import { majorOf } from './semver';
 export const SPHERE_CONNECT_NAMESPACE = 'sphere-connect';
 export const SPHERE_CONNECT_VERSION = '2.1';   // Connect protocol version (semver MAJOR.MINOR)
 
-// Default npm-SDK floor a host enforces at the handshake. 0.15.0 is the
-// state-transition-sdk 3.x line: the Connect WIRE did not change, but
-// `sphere_getTokens` hands raw token CBOR across it, and a client on the 2.x line
-// cannot decode a 3.x token — it fails with "Unsupported Token version". Such a
-// client is already non-functional against this wallet, so the floor turns a
-// cryptic decode failure deep in the dApp into one legible refusal at the
-// handshake. '-0' admits every 0.15.0 prerelease (compareSemver: release >
-// prerelease), which is what we want: those pin the 3.x SDK too.
-// Override via ConnectHostConfig.minSdkVersion; the claim is compatibility
-// hygiene, not security — a hostile client can lie about it.
+// Default npm-SDK floor a host enforces at the handshake; '-0' admits every
+// prerelease of that version (compareSemver: release > prerelease). Override via
+// ConnectHostConfig.minSdkVersion; the claim is compatibility hygiene, not
+// security — a hostile client can lie about it. Which version, and why, is
+// argued in docs/CONNECT.md under "SDK version floor".
 export const DEFAULT_MIN_CLIENT_SDK_VERSION = '0.15.0-0';
 
 export { HOST_READY_TYPE, HOST_READY_TIMEOUT, SPHERE_NETWORKS } from '../constants';

--- a/docs/CONNECT.md
+++ b/docs/CONNECT.md
@@ -9,8 +9,9 @@ The current Connect protocol version is **`2.1`** (`SPHERE_CONNECT_VERSION = '2.
 > **sphere-sdk 0.15.0 does NOT bump it.** That release is a hard wire break on the
 > *state-transition* protocol, but Connect messages carry no state-transition bytes — the token
 > blob never crosses this wire (`sphere_getTokens` strips `sdkData`, as it always has). Method
-> list, params, result shapes, events, scopes and error codes are byte-identical to 0.14.x, and
-> the `minSdkVersion` floor stays `0.14.1-0`. What changed is wallet-host-side: see
+> list, params, result shapes, events, scopes and error codes are byte-identical to 0.14.x.
+> The `minSdkVersion` floor DOES move, to `0.15.0-0` — see below. What else changed is
+> wallet-host-side: see
 > [ConnectHost: the `SphereInstance` contract](#connecthost-the-sphereinstance-contract).
 
 ### Compatibility policy
@@ -21,11 +22,15 @@ The current Connect protocol version is **`2.1`** (`SPHERE_CONNECT_VERSION = '2.
 
 ### Handshake fields
 
-> **SDK version floor (0.14.1, the P11 flip):** the host rejects any client whose handshake
-> `sdkVersion` is missing or below `0.14.1-0` (every 0.14.1 prerelease passes) with
-> `UNSUPPORTED_PROTOCOL_VERSION` (4007) and a message naming the required minimum — pre-flip
-> clients expect a wallet surface that no longer exists. Override via
-> `ConnectHostConfig.minSdkVersion`. The claim is compatibility hygiene, not security.
+> **SDK version floor (`0.15.0-0`, the state-transition-sdk 3.x line):** the host rejects any
+> client whose handshake `sdkVersion` is missing or below `0.15.0-0` (every 0.15.0 prerelease
+> passes — those pin the 3.x SDK too) with `UNSUPPORTED_PROTOCOL_VERSION` (4007) and a message
+> naming the required minimum. The Connect wire did not change, but `sphere_getTokens` hands raw
+> token CBOR across it and a client on the 2.x line cannot decode a 3.x token — it fails with
+> `Unsupported Token version`. Such a client is already non-functional against this wallet, so
+> the floor turns a cryptic decode failure deep in the dApp into one legible refusal at the
+> handshake. Override via `ConnectHostConfig.minSdkVersion`. The claim is compatibility hygiene,
+> not security — a hostile client can lie about it.
 
 Two new optional fields are sent in the handshake (added in v2; both fields are additive and carry no breaking change to the wire format):
 

--- a/docs/MIGRATION-PAYMENTS-V2.md
+++ b/docs/MIGRATION-PAYMENTS-V2.md
@@ -176,11 +176,13 @@ which such clients never read; across the 3.x break they are simply gone.
 The Connect wire contract is preserved by the host adapter: `sphere_getBalance`,
 `sphere_getFiatBalance`, `sphere_getHistory` and the old event names keep
 working against a v2 host. dApp builders need ONE change: bump
-`@unicitylabs/sphere-sdk` to **≥ 0.14.1** — 0.14.1+ wallet hosts enforce an SDK
-version floor at the handshake (`UNSUPPORTED_PROTOCOL_VERSION` with a message
-naming the minimum; pre-0.14.1 clients don't report a version and are rejected
-as such — the floor is still `0.14.1-0` in 0.15.0). Invoice-surface consumers
-additionally see §4.
+`@unicitylabs/sphere-sdk` to **≥ 0.15.0** — wallet hosts enforce an SDK version
+floor at the handshake (`UNSUPPORTED_PROTOCOL_VERSION` with a message naming the
+minimum; clients that report no version are rejected as such). The floor MOVED
+to `0.15.0-0` with the 3.x bump: the wire is unchanged, but `sphere_getTokens`
+hands raw token CBOR across it and a 2.x-line client cannot decode a 3.x token,
+so it is already non-functional against a 0.15.x wallet. Invoice-surface
+consumers additionally see §4.
 
 **Wallet hosts (not dApps) see one shape change in 0.15.0.** With the
 `paymentsV2` alias gone, the `SphereInstance` a `ConnectHost` is constructed

--- a/tests/unit/connect/compatibility.test.ts
+++ b/tests/unit/connect/compatibility.test.ts
@@ -56,15 +56,17 @@ describe('checkCompatibility', () => {
   it('passes when the SDK floor is met', () => {
     expect(checkCompatibility({ clientProtocol: '2.0', walletProtocol: W, clientNetwork: { id: NET }, walletNetworkId: NET, clientSdkVersion: '0.10.0', minSdkVersion: '0.10.0' }).ok).toBe(true);
   });
-  it('the P11 default floor 0.14.1-0 rejects every pre-flip client (0.13.x, 0.14.0) and unreported versions', () => {
-    for (const v of ['0.13.3', '0.14.0', '0.14.0-dev.9', undefined]) {
+  it('the 3.x default floor rejects every 2.x-line client — they cannot decode a v3 token — and unreported versions', () => {
+    for (const v of ['0.13.3', '0.14.0', '0.14.0-dev.9', '0.14.1', '0.14.11', '0.14.11-dev.8', undefined]) {
       const r = checkCompatibility({ clientProtocol: '2.0', walletProtocol: W, clientNetwork: { id: NET }, walletNetworkId: NET, ...(v !== undefined ? { clientSdkVersion: v } : {}), minSdkVersion: DEFAULT_MIN_CLIENT_SDK_VERSION });
       expect(r.ok, `expected reject for ${v ?? 'unreported'}`).toBe(false);
     }
   });
 
-  it('the P11 default floor admits the 0.14.1 prerelease track and everything newer', () => {
-    for (const v of ['0.14.1-dev.0', '0.14.1-dev.1', '0.14.1', '0.14.2', '0.15.0-dev.2', '1.0.0']) {
+  it('the 3.x default floor admits the 0.15.0 prerelease track and everything newer', () => {
+    // 0.15.0-dev.* pin state-transition-sdk 3.x, so they can decode what this
+    // wallet serves; the floor is about the SDK line, not about being a release.
+    for (const v of ['0.15.0-dev.1', '0.15.0-dev.2', '0.15.0', '0.15.1', '0.16.0', '1.0.0']) {
       expect(
         checkCompatibility({ clientProtocol: '2.0', walletProtocol: W, clientNetwork: { id: NET }, walletNetworkId: NET, clientSdkVersion: v, minSdkVersion: DEFAULT_MIN_CLIENT_SDK_VERSION }).ok,
         `expected accept for ${v}`

--- a/tests/unit/connect/gate.test.ts
+++ b/tests/unit/connect/gate.test.ts
@@ -120,14 +120,14 @@ describe('ConnectHost gate', () => {
     expect(handshakeResponses(h.sent)[0].v).toBe('1.0');
   });
 
-  it('P11 floor is the DEFAULT: a hello with no sdkVersion (any pre-0.14.1 client) is rejected naming the minimum', async () => {
+  it('the 3.x floor is the DEFAULT: a hello with no sdkVersion (any pre-0.15.0 client) is rejected naming the minimum', async () => {
     const h = makeHostHarness();
     h.send({ v: SPHERE_CONNECT_VERSION, dapp: { name: 'old-app', url: 'https://old-app' }, network: { id: WALLET_NET } });
     await Promise.resolve();
     const resp = handshakeResponses(h.sent)[0];
     const err = resp.error as { code: number; message: string };
     expect(err.code).toBe(ERROR_CODES.UNSUPPORTED_PROTOCOL_VERSION);
-    expect(err.message).toContain('0.14.1-0');
+    expect(err.message).toContain('0.15.0-0');
     expect(err.message).toContain('unknown (not reported)');
     expect(h.onConnectionRequest).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Moves `DEFAULT_MIN_CLIENT_SDK_VERSION` from `0.14.1-0` to **`0.15.0-0`**.

I left the floor alone during the 3.x bump, on the reasoning that the Connect wire was unchanged. That reasoning was incomplete: `sphere_getTokens` hands raw token CBOR across the wire, and a 2.x-line client cannot decode a 3.x token — it fails with `Unsupported Token version`. The wire is fine; the payload crossing it is not.

**This rejects nothing that worked.** Every client it now refuses was already unable to read a token from a 0.15.x wallet. It just discovered that as a cryptic decode failure inside its own code, rather than as one refusal at the handshake naming the minimum it needs.

`-0` admits the whole `0.15.0` prerelease track deliberately — those pin state-transition-sdk 3.x too, so they can decode what the wallet serves. The floor is about the SDK line, not about being a released version. Verified against the real comparator:

```
floor = 0.15.0-0
   0.13.3           reject
   0.14.1           reject
   0.14.11          reject
   0.14.11-dev.8    reject
   0.15.0-dev.1     ACCEPT
   0.15.0           ACCEPT
   0.15.1           ACCEPT
   1.0.0            ACCEPT
   (no version)     reject — "SDK version unknown (not reported) is below the required minimum 0.15.0-0"
```

Hosts that set `ConnectHostConfig.minSdkVersion` explicitly are unaffected. The claim stays compatibility hygiene, not security — a hostile client can misreport its version.

Docs corrected too: `docs/CONNECT.md` and `docs/MIGRATION-PAYMENTS-V2.md` both said the floor stays at `0.14.1-0` in 0.15.0, which I wrote and which is now false.

2040 tests, lint 0 errors, typecheck clean.

Closes #762