### PR TITLE
refactor(registry): a Sphere owns its token registry, and destroy() disposes it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — a Sphere owns its token registry, and destroy() disposes it (#766)
+
+`TokenRegistry` is a process-global singleton whose `configure()` repoints whatever instance
+exists, and every `Sphere.init()` calls it. So a second Sphere silently rewrote the first one's
+metadata. Observed with two Spheres on **separate storage providers**: initialising a mainnet
+Sphere flipped a live testnet2 wallet's own asset from `{symbol:'TCOIN', decimals:8}` to
+`{symbol:'AAAAAA', decimals:0}` — the registry-miss fallbacks. Nothing restored it.
+
+Inside the SDK that is presentation only (the money path treats `coinId` as opaque bytes), but
+not at the consumer boundary: code that takes `decimals` or a `coinId` from the registry and
+feeds it to an amount conversion or to `send()`/`mint()` gets a 10ⁿ scale error or the wrong
+coin. See [docs/MIGRATION-TOKEN-REGISTRY.md](docs/MIGRATION-TOKEN-REGISTRY.md).
+
+- A `Sphere` now builds and owns its own registry, and the payments facade presents from it.
+  Two Spheres on different networks no longer disturb each other.
+- `Sphere.destroy()` disposes that registry. Previously `destroy()` never touched it, so every
+  discarded Sphere left an hourly fetch running — and nothing in `registry/` calls `unref()`,
+  so under Node it kept the event loop alive too.
+- New: `TokenRegistry.create(options)`, plus instance `dispose()`, `isDisposed` and
+  `waitForReady()`. The statics are unchanged and still drive the global.
+- `createBrowserProviders` / `createNodeProviders` no longer call `TokenRegistry.configure()`.
+  In the published package those bundles carry their own inlined copy that no consumer can
+  reach (`tsup` inlines `registry/` per entry with `splitting: false`), so the call was writing
+  to an unreadable object and holding an unstoppable interval. Removing it is a no-op for
+  package consumers; if you use a provider factory WITHOUT `Sphere.init()` and read the global,
+  configure it yourself — the migration guide has the two lines.
+- The ten singleton-bound free functions moved to `registry/global-readers.ts`, re-exported
+  unchanged. The public surface is identical: same 126 root exports, same signatures.
+
+Not fixed here: `Sphere`'s own `static instance`, and `Sphere.clear()`/`import()` destroying
+whichever instance holds it regardless of the storage they were given. Tracked in #766.
+
 ### Added — mainnet is a runnable network
 
 `network: 'mainnet'` now constructs and verifies. Previously the provider factories refused it

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -804,6 +804,26 @@ export class Sphere {
    * Sphere's init. The global is still configured above for consumers that read it
    * directly; this instance is what the payments facade presents from.
    */
+  /**
+   * Build this Sphere's registry, then bring up its providers — disposing the registry if
+   * that fails. Built here rather than at construction so an earlier rejection (a bad
+   * mnemonic, a wrong password) never strands one: the caller gets no Sphere to destroy.
+   */
+  private static async buildRegistryAndInitProviders(
+    sphere: Sphere,
+    storage: StorageProvider,
+    network?: NetworkType,
+  ): Promise<void> {
+    sphere._registry = Sphere.createOwnedRegistry(storage, network);
+    try {
+      await sphere.initializeProviders();
+    } catch (err) {
+      sphere._registry?.dispose();
+      sphere._registry = null;
+      throw err;
+    }
+  }
+
   private static createOwnedRegistry(storage: StorageProvider, network?: NetworkType): TokenRegistry {
     if (!network) {
       throw new SphereError(
@@ -871,16 +891,7 @@ export class Sphere {
 
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
-    // Built here, not at construction: an earlier failure (a rejected mnemonic, a bad
-    // password) would otherwise leave an unreachable registry fetching hourly forever.
-    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
-    try {
-      await sphere.initializeProviders();
-    } catch (err) {
-      sphere._registry?.dispose();
-      sphere._registry = null;
-      throw err;
-    }
+    await Sphere.buildRegistryAndInitProviders(sphere, options.storage, options.network);
     await sphere.initializeModules();
 
     // Mark wallet as created only after successful initialization
@@ -981,16 +992,7 @@ export class Sphere {
 
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
-    // Built here, not at construction: an earlier failure (a rejected mnemonic, a bad
-    // password) would otherwise leave an unreachable registry fetching hourly forever.
-    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
-    try {
-      await sphere.initializeProviders();
-    } catch (err) {
-      sphere._registry?.dispose();
-      sphere._registry = null;
-      throw err;
-    }
+    await Sphere.buildRegistryAndInitProviders(sphere, options.storage, options.network);
     await sphere.initializeModules();
 
     // Publish identity binding via transport
@@ -1116,16 +1118,7 @@ export class Sphere {
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
     logger.debug('Sphere', 'Initializing providers...');
-    // Built here, not at construction: an earlier failure (a rejected mnemonic, a bad
-    // password) would otherwise leave an unreachable registry fetching hourly forever.
-    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
-    try {
-      await sphere.initializeProviders();
-    } catch (err) {
-      sphere._registry?.dispose();
-      sphere._registry = null;
-      throw err;
-    }
+    await Sphere.buildRegistryAndInitProviders(sphere, options.storage, options.network);
     logger.debug('Sphere', 'Providers initialized. Initializing modules...');
     await sphere.initializeModules();
     logger.debug('Sphere', 'Modules initialized');

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -3443,6 +3443,32 @@ export class Sphere {
   // Public Methods - Lifecycle
   // ===========================================================================
 
+  /**
+   * Disconnect transport, storage and oracle, attempting each even if an earlier one
+   * rejects. They are separate resources, and one failure must not skip the rest — that
+   * is how a partial teardown leaves connections open, which is exactly the state the
+   * failed-initialization path calls destroy() in.
+   */
+  private async disconnectProvidersIndependently(): Promise<void> {
+    const steps: ReadonlyArray<readonly [string, () => Promise<void>]> = [
+      ['transport', () => this._transport.disconnect()],
+      ['storage', () => this._storage.disconnect()],
+      ['oracle', () => this._oracle.disconnect()],
+    ];
+    for (const [what, disconnect] of steps) {
+      await Sphere.safeDisconnect(what, disconnect);
+    }
+  }
+
+  /** Run one teardown step, logging rather than propagating so the next one still runs. */
+  private static async safeDisconnect(what: string, run: () => Promise<void>): Promise<void> {
+    try {
+      await run();
+    } catch (err) {
+      logger.warn('Sphere', `${what} disconnect failed during destroy:`, err);
+    }
+  }
+
   async destroy(): Promise<void> {
     // FIRST, before anything that can throw. Module teardown and
     // MultiAddressTransportMux.disconnect() propagate, so any later placement would let a
@@ -3484,7 +3510,8 @@ export class Sphere {
 
     // Disconnect transport mux if present
     if (this._transportMux) {
-      await this._transportMux.disconnect();
+      const mux = this._transportMux;
+      await Sphere.safeDisconnect('transport mux', () => mux.disconnect());
       this._transportMux = null;
     }
 
@@ -3492,9 +3519,7 @@ export class Sphere {
     // above (dispose is idempotent, so an overlap is harmless).
     this._tokenEngine?.dispose?.();
 
-    await this._transport.disconnect();
-    await this._storage.disconnect();
-    await this._oracle.disconnect();
+    await this.disconnectProvidersIndependently();
 
     this._initialized = false;
     this._trackedAddressesLoaded = false;

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -858,7 +858,6 @@ export class Sphere {
       options.communications,
     );
     sphere._verification = options.verification;
-    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
     sphere._paymentsV2Composition = composition;
     sphere._password = options.password ?? null;
     sphere._passwordProtected = sphere._password !== null;
@@ -872,7 +871,16 @@ export class Sphere {
 
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
-    await sphere.initializeProviders();
+    // Built here, not at construction: an earlier failure (a rejected mnemonic, a bad
+    // password) would otherwise leave an unreachable registry fetching hourly forever.
+    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
+    try {
+      await sphere.initializeProviders();
+    } catch (err) {
+      sphere._registry?.dispose();
+      sphere._registry = null;
+      throw err;
+    }
     await sphere.initializeModules();
 
     // Mark wallet as created only after successful initialization
@@ -958,7 +966,6 @@ export class Sphere {
       options.communications,
     );
     sphere._verification = options.verification;
-    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
     sphere._paymentsV2Composition = composition;
     sphere._password = options.password ?? null;
     sphere._passwordProtected = sphere._password !== null;
@@ -974,7 +981,16 @@ export class Sphere {
 
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
-    await sphere.initializeProviders();
+    // Built here, not at construction: an earlier failure (a rejected mnemonic, a bad
+    // password) would otherwise leave an unreachable registry fetching hourly forever.
+    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
+    try {
+      await sphere.initializeProviders();
+    } catch (err) {
+      sphere._registry?.dispose();
+      sphere._registry = null;
+      throw err;
+    }
     await sphere.initializeModules();
 
     // Publish identity binding via transport
@@ -1064,7 +1080,6 @@ export class Sphere {
       options.communications,
     );
     sphere._verification = options.verification;
-    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
     sphere._paymentsV2Composition = composition;
     sphere._password = options.password ?? null;
     sphere._passwordProtected = sphere._password !== null;
@@ -1101,7 +1116,16 @@ export class Sphere {
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
     logger.debug('Sphere', 'Initializing providers...');
-    await sphere.initializeProviders();
+    // Built here, not at construction: an earlier failure (a rejected mnemonic, a bad
+    // password) would otherwise leave an unreachable registry fetching hourly forever.
+    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
+    try {
+      await sphere.initializeProviders();
+    } catch (err) {
+      sphere._registry?.dispose();
+      sphere._registry = null;
+      throw err;
+    }
     logger.debug('Sphere', 'Providers initialized. Initializing modules...');
     await sphere.initializeModules();
     logger.debug('Sphere', 'Modules initialized');
@@ -3409,6 +3433,12 @@ export class Sphere {
   // ===========================================================================
 
   async destroy(): Promise<void> {
+    // FIRST, before anything that can throw. Module teardown and
+    // MultiAddressTransportMux.disconnect() propagate, so any later placement would let a
+    // single failure leave this Sphere's registry fetching forever. Nothing below needs it.
+    this._registry?.dispose();
+    this._registry = null;
+
     this.cleanupProviderEventSubscriptions();
 
     // Stop the payments vertical FIRST — stop() awaits quiescence, so
@@ -3450,13 +3480,6 @@ export class Sphere {
     // The active engine, when it is not one of the per-address engines disposed
     // above (dispose is idempotent, so an overlap is harmless).
     this._tokenEngine?.dispose?.();
-
-    // Stop this Sphere's own registry: its hourly fetch would otherwise outlive the
-    // wallet that created it (nothing in registry/ calls unref(), so in Node it also
-    // keeps the event loop alive). The process-global is deliberately left alone —
-    // other code still reads it.
-    this._registry?.dispose();
-    this._registry = null;
 
     await this._transport.disconnect();
     await this._storage.disconnect();

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -805,11 +805,13 @@ export class Sphere {
    * directly; this instance is what the payments facade presents from.
    */
   /**
-   * Build this Sphere's registry, then bring up its providers — disposing the registry if
-   * that fails. Built here rather than at construction so an earlier rejection (a bad
-   * mnemonic, a wrong password) never strands one: the caller gets no Sphere to destroy.
+   * Build this Sphere's registry, then bring up providers AND modules — disposing the
+   * registry if any of it fails. Built here rather than at construction so an earlier
+   * rejection (a bad mnemonic, a wrong password) never strands one: the caller gets no
+   * Sphere to destroy. Module bring-up is inside the guard because it is fallible too —
+   * an oracle with no trust base makes startPaymentsV2Inner throw INVALID_CONFIG.
    */
-  private static async buildRegistryAndInitProviders(
+  private static async buildRegistryAndBringUp(
     sphere: Sphere,
     storage: StorageProvider,
     network?: NetworkType,
@@ -817,6 +819,7 @@ export class Sphere {
     sphere._registry = Sphere.createOwnedRegistry(storage, network);
     try {
       await sphere.initializeProviders();
+      await sphere.initializeModules();
     } catch (err) {
       sphere._registry?.dispose();
       sphere._registry = null;
@@ -891,8 +894,7 @@ export class Sphere {
 
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
-    await Sphere.buildRegistryAndInitProviders(sphere, options.storage, options.network);
-    await sphere.initializeModules();
+    await Sphere.buildRegistryAndBringUp(sphere, options.storage, options.network);
 
     // Mark wallet as created only after successful initialization
     // This prevents "Wallet already exists" errors if init fails partway through
@@ -992,8 +994,7 @@ export class Sphere {
 
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
-    await Sphere.buildRegistryAndInitProviders(sphere, options.storage, options.network);
-    await sphere.initializeModules();
+    await Sphere.buildRegistryAndBringUp(sphere, options.storage, options.network);
 
     // Publish identity binding via transport
     progress?.({ step: 'syncing_identity', message: 'Publishing identity...' });
@@ -1118,9 +1119,7 @@ export class Sphere {
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
     logger.debug('Sphere', 'Initializing providers...');
-    await Sphere.buildRegistryAndInitProviders(sphere, options.storage, options.network);
-    logger.debug('Sphere', 'Providers initialized. Initializing modules...');
-    await sphere.initializeModules();
+    await Sphere.buildRegistryAndBringUp(sphere, options.storage, options.network);
     logger.debug('Sphere', 'Modules initialized');
 
     // Try to recover nametag from transport (if no nametag provided and wallet previously had one)

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -528,6 +528,8 @@ export class Sphere {
    * the rebuild after an api-key change share one pool configuration.
    */
   private _verification: VerificationWorkerConfig | undefined;
+  /** This Sphere's OWN token registry. Disposed by destroy(); never the process global. */
+  private _registry: TokenRegistry | null = null;
 
   // Events
   private eventHandlers: Map<SphereEventType, Set<SphereEventHandler<SphereEventType>>> = new Map();
@@ -798,6 +800,21 @@ export class Sphere {
   }
 
   /**
+   * Build the registry THIS Sphere owns, so its metadata cannot be repointed by another
+   * Sphere's init. The global is still configured above for consumers that read it
+   * directly; this instance is what the payments facade presents from.
+   */
+  private static createOwnedRegistry(storage: StorageProvider, network?: NetworkType): TokenRegistry {
+    if (!network) {
+      throw new SphereError(
+        'network is required to build the token registry. Every Sphere entry point must forward options.network.',
+        'INVALID_CONFIG',
+      );
+    }
+    return TokenRegistry.create({ remoteUrl: NETWORKS[network].tokenRegistryUrl, storage });
+  }
+
+  /**
    * Create new wallet with mnemonic
    */
   static async create(options: SphereCreateOptions): Promise<Sphere> {
@@ -841,6 +858,7 @@ export class Sphere {
       options.communications,
     );
     sphere._verification = options.verification;
+    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
     sphere._paymentsV2Composition = composition;
     sphere._password = options.password ?? null;
     sphere._passwordProtected = sphere._password !== null;
@@ -940,6 +958,7 @@ export class Sphere {
       options.communications,
     );
     sphere._verification = options.verification;
+    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
     sphere._paymentsV2Composition = composition;
     sphere._password = options.password ?? null;
     sphere._passwordProtected = sphere._password !== null;
@@ -1045,6 +1064,7 @@ export class Sphere {
       options.communications,
     );
     sphere._verification = options.verification;
+    sphere._registry = Sphere.createOwnedRegistry(options.storage, options.network);
     sphere._paymentsV2Composition = composition;
     sphere._password = options.password ?? null;
     sphere._passwordProtected = sphere._password !== null;
@@ -3431,6 +3451,13 @@ export class Sphere {
     // above (dispose is idempotent, so an overlap is harmless).
     this._tokenEngine?.dispose?.();
 
+    // Stop this Sphere's own registry: its hourly fetch would otherwise outlive the
+    // wallet that created it (nothing in registry/ calls unref(), so in Node it also
+    // keeps the event loop alive). The process-global is deliberately left alone —
+    // other code still reads it.
+    this._registry?.dispose();
+    this._registry = null;
+
     await this._transport.disconnect();
     await this._storage.disconnect();
     await this._oracle.disconnect();
@@ -3971,6 +3998,7 @@ export class Sphere {
       host: {
         storage: this._storage,
         price: this._priceProvider,
+        registry: this._registry ?? TokenRegistry.getInstance(),
         emit: (event, payload) =>
           this.emitEvent(event as SphereEventType, payload as SphereEventMap[SphereEventType]),
         resolvePeer: (identifier) => this._transport.resolve?.(identifier) ?? Promise.resolve(null),

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -805,21 +805,23 @@ export class Sphere {
    * directly; this instance is what the payments facade presents from.
    */
   /**
-   * Build this Sphere's registry, then bring up providers AND modules — disposing the
-   * registry if any of it fails. Built here rather than at construction so an earlier
-   * rejection (a bad mnemonic, a wrong password) never strands one: the caller gets no
-   * Sphere to destroy. Module bring-up is inside the guard because it is fallible too —
-   * an oracle with no trust base makes startPaymentsV2Inner throw INVALID_CONFIG.
+   * Own a registry for the duration of `bringUp`, disposing it if any of that rejects.
+   *
+   * `bringUp` must cover EVERY fallible step from here until the Sphere is published to
+   * `Sphere.instance` — until then the caller receives nothing it could destroy, so a
+   * registry left behind is unreachable and its hourly fetch runs for the life of the
+   * process. Guarding a named subset of the steps is what failed twice: the guarded region
+   * and the fallible region were separate things, and drifted.
    */
-  private static async buildRegistryAndBringUp(
+  private static async withOwnedRegistry(
     sphere: Sphere,
     storage: StorageProvider,
-    network?: NetworkType,
+    network: NetworkType | undefined,
+    bringUp: () => Promise<void>,
   ): Promise<void> {
     sphere._registry = Sphere.createOwnedRegistry(storage, network);
     try {
-      await sphere.initializeProviders();
-      await sphere.initializeModules();
+      await bringUp();
     } catch (err) {
       sphere._registry?.dispose();
       sphere._registry = null;
@@ -894,14 +896,17 @@ export class Sphere {
 
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
-    await Sphere.buildRegistryAndBringUp(sphere, options.storage, options.network);
+    await Sphere.withOwnedRegistry(sphere, options.storage, options.network, async () => {
+      await sphere.initializeProviders();
+      await sphere.initializeModules();
 
-    // Mark wallet as created only after successful initialization
-    // This prevents "Wallet already exists" errors if init fails partway through
-    progress?.({ step: 'finalizing', message: 'Finalizing wallet...' });
-    await sphere.finalizeWalletCreation();
+      // Mark wallet as created only after successful initialization
+      // This prevents "Wallet already exists" errors if init fails partway through
+      progress?.({ step: 'finalizing', message: 'Finalizing wallet...' });
+      await sphere.finalizeWalletCreation();
 
-    sphere._initialized = true;
+      sphere._initialized = true;
+    });
     Sphere.instance = sphere;
 
     // Track address 0 in the registry
@@ -994,13 +999,16 @@ export class Sphere {
 
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
-    await Sphere.buildRegistryAndBringUp(sphere, options.storage, options.network);
+    await Sphere.withOwnedRegistry(sphere, options.storage, options.network, async () => {
+      await sphere.initializeProviders();
+      await sphere.initializeModules();
 
-    // Publish identity binding via transport
-    progress?.({ step: 'syncing_identity', message: 'Publishing identity...' });
-    await sphere.syncIdentityWithTransport();
+      // Publish identity binding via transport
+      progress?.({ step: 'syncing_identity', message: 'Publishing identity...' });
+      await sphere.syncIdentityWithTransport();
 
-    sphere._initialized = true;
+      sphere._initialized = true;
+    });
     Sphere.instance = sphere;
 
     // Auto-discover previously used HD addresses
@@ -1119,26 +1127,29 @@ export class Sphere {
     // Initialize everything
     progress?.({ step: 'initializing', message: 'Initializing wallet...' });
     logger.debug('Sphere', 'Initializing providers...');
-    await Sphere.buildRegistryAndBringUp(sphere, options.storage, options.network);
-    logger.debug('Sphere', 'Modules initialized');
+    await Sphere.withOwnedRegistry(sphere, options.storage, options.network, async () => {
+      await sphere.initializeProviders();
+      await sphere.initializeModules();
+      logger.debug('Sphere', 'Modules initialized');
 
-    // Try to recover nametag from transport (if no nametag provided and wallet previously had one)
-    if (!options.nametag) {
-      progress?.({ step: 'recovering_nametag', message: 'Recovering nametag...' });
-      logger.debug('Sphere', 'Recovering Unicity ID from transport...');
-      await sphere.recoverNametagFromTransport();
-      logger.debug('Sphere', 'Unicity ID recovery done');
-      // Publish identity binding (with recovered nametag if found)
-      progress?.({ step: 'syncing_identity', message: 'Publishing identity...' });
-      await sphere.syncIdentityWithTransport();
-    }
+      // Try to recover nametag from transport (if no nametag provided and wallet previously had one)
+      if (!options.nametag) {
+        progress?.({ step: 'recovering_nametag', message: 'Recovering nametag...' });
+        logger.debug('Sphere', 'Recovering Unicity ID from transport...');
+        await sphere.recoverNametagFromTransport();
+        logger.debug('Sphere', 'Unicity ID recovery done');
+        // Publish identity binding (with recovered nametag if found)
+        progress?.({ step: 'syncing_identity', message: 'Publishing identity...' });
+        await sphere.syncIdentityWithTransport();
+      }
 
-    // Mark wallet as created only after successful initialization
-    progress?.({ step: 'finalizing', message: 'Finalizing wallet...' });
-    logger.debug('Sphere', 'Finalizing wallet creation...');
-    await sphere.finalizeWalletCreation();
+      // Mark wallet as created only after successful initialization
+      progress?.({ step: 'finalizing', message: 'Finalizing wallet creation...' });
+      logger.debug('Sphere', 'Finalizing wallet creation...');
+      await sphere.finalizeWalletCreation();
 
-    sphere._initialized = true;
+      sphere._initialized = true;
+    });
     Sphere.instance = sphere;
 
     // Track address 0 in the registry

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -906,48 +906,49 @@ export class Sphere {
       await sphere.finalizeWalletCreation();
 
       sphere._initialized = true;
-    });
-    Sphere.instance = sphere;
 
-    // Track address 0 in the registry
-    await sphere.ensureAddressTracked(0);
+      // Track address 0 in the registry
+      await sphere.ensureAddressTracked(0);
 
-    // Register nametag if provided, otherwise try recovery then publish
-    if (options.nametag) {
-      progress?.({ step: 'registering_nametag', message: 'Registering nametag...' });
-      // registerNametag publishes identity binding WITH nametag atomically
-      // (calling syncIdentityWithTransport before this would race — both replaceable
-      // events get the same created_at second and relay keeps the one without nametag)
-      await sphere.registerNametag(options.nametag);
-    } else {
-      // Try to recover nametag BEFORE publishing — publishIdentityBinding uses
-      // kind 30078 (replaceable event), so a bare binding would overwrite the
-      // existing one that contains encrypted_nametag, making recovery impossible.
-      progress?.({ step: 'recovering_nametag', message: 'Recovering nametag...' });
-      await sphere.recoverNametagFromTransport();
-      // Now publish identity binding (with recovered nametag if found)
-      progress?.({ step: 'syncing_identity', message: 'Publishing identity...' });
-      await sphere.syncIdentityWithTransport();
-    }
-
-    // Auto-discover previously used HD addresses
-    if (options.discoverAddresses !== false && sphere._transport.discoverAddresses) {
-      progress?.({ step: 'discovering_addresses', message: 'Discovering addresses...' });
-      try {
-        const discoverOpts: DiscoverAddressesOptions =
-          typeof options.discoverAddresses === 'object'
-            ? { ...options.discoverAddresses, autoTrack: options.discoverAddresses.autoTrack ?? true }
-            : { autoTrack: true };
-        const result = await sphere.discoverAddresses(discoverOpts);
-        if (result.addresses.length > 0) {
-          logger.debug('Sphere', `Address discovery: found ${result.addresses.length} address(es)`);
-        }
-      } catch (err) {
-        logger.warn('Sphere', 'Address discovery failed (non-fatal):', err);
+      // Register nametag if provided, otherwise try recovery then publish
+      if (options.nametag) {
+        progress?.({ step: 'registering_nametag', message: 'Registering nametag...' });
+        // registerNametag publishes identity binding WITH nametag atomically
+        // (calling syncIdentityWithTransport before this would race — both replaceable
+        // events get the same created_at second and relay keeps the one without nametag)
+        await sphere.registerNametag(options.nametag);
+      } else {
+        // Try to recover nametag BEFORE publishing — publishIdentityBinding uses
+        // kind 30078 (replaceable event), so a bare binding would overwrite the
+        // existing one that contains encrypted_nametag, making recovery impossible.
+        progress?.({ step: 'recovering_nametag', message: 'Recovering nametag...' });
+        await sphere.recoverNametagFromTransport();
+        // Now publish identity binding (with recovered nametag if found)
+        progress?.({ step: 'syncing_identity', message: 'Publishing identity...' });
+        await sphere.syncIdentityWithTransport();
       }
-    }
 
-    progress?.({ step: 'complete', message: 'Wallet created' });
+      // Auto-discover previously used HD addresses
+      if (options.discoverAddresses !== false && sphere._transport.discoverAddresses) {
+        progress?.({ step: 'discovering_addresses', message: 'Discovering addresses...' });
+        try {
+          const discoverOpts: DiscoverAddressesOptions =
+            typeof options.discoverAddresses === 'object'
+              ? { ...options.discoverAddresses, autoTrack: options.discoverAddresses.autoTrack ?? true }
+              : { autoTrack: true };
+          const result = await sphere.discoverAddresses(discoverOpts);
+          if (result.addresses.length > 0) {
+            logger.debug('Sphere', `Address discovery: found ${result.addresses.length} address(es)`);
+          }
+        } catch (err) {
+          logger.warn('Sphere', 'Address discovery failed (non-fatal):', err);
+        }
+      }
+
+      progress?.({ step: 'complete', message: 'Wallet created' });
+    });
+
+    Sphere.instance = sphere;
     return sphere;
   }
 
@@ -1008,27 +1009,28 @@ export class Sphere {
       await sphere.syncIdentityWithTransport();
 
       sphere._initialized = true;
-    });
-    Sphere.instance = sphere;
 
-    // Auto-discover previously used HD addresses
-    if (options.discoverAddresses !== false && sphere._transport.discoverAddresses && sphere._masterKey) {
-      progress?.({ step: 'discovering_addresses', message: 'Discovering addresses...' });
-      try {
-        const discoverOpts: DiscoverAddressesOptions =
-          typeof options.discoverAddresses === 'object'
-            ? { ...options.discoverAddresses, autoTrack: options.discoverAddresses.autoTrack ?? true }
-            : { autoTrack: true };
-        const result = await sphere.discoverAddresses(discoverOpts);
-        if (result.addresses.length > 0) {
-          logger.debug('Sphere', `Address discovery: found ${result.addresses.length} address(es)`);
+      // Auto-discover previously used HD addresses
+      if (options.discoverAddresses !== false && sphere._transport.discoverAddresses && sphere._masterKey) {
+        progress?.({ step: 'discovering_addresses', message: 'Discovering addresses...' });
+        try {
+          const discoverOpts: DiscoverAddressesOptions =
+            typeof options.discoverAddresses === 'object'
+              ? { ...options.discoverAddresses, autoTrack: options.discoverAddresses.autoTrack ?? true }
+              : { autoTrack: true };
+          const result = await sphere.discoverAddresses(discoverOpts);
+          if (result.addresses.length > 0) {
+            logger.debug('Sphere', `Address discovery: found ${result.addresses.length} address(es)`);
+          }
+        } catch (err) {
+          logger.warn('Sphere', 'Address discovery failed (non-fatal):', err);
         }
-      } catch (err) {
-        logger.warn('Sphere', 'Address discovery failed (non-fatal):', err);
       }
-    }
 
-    progress?.({ step: 'complete', message: 'Wallet loaded' });
+      progress?.({ step: 'complete', message: 'Wallet loaded' });
+    });
+
+    Sphere.instance = sphere;
     return sphere;
   }
 
@@ -1149,39 +1151,40 @@ export class Sphere {
       await sphere.finalizeWalletCreation();
 
       sphere._initialized = true;
-    });
-    Sphere.instance = sphere;
 
-    // Track address 0 in the registry
-    logger.debug('Sphere', 'Tracking address 0...');
-    await sphere.ensureAddressTracked(0);
+      // Track address 0 in the registry
+      logger.debug('Sphere', 'Tracking address 0...');
+      await sphere.ensureAddressTracked(0);
 
-    // Register nametag if provided (this overrides any recovered nametag)
-    if (options.nametag) {
-      progress?.({ step: 'registering_nametag', message: 'Registering nametag...' });
-      logger.debug('Sphere', 'Registering Unicity ID...');
-      await sphere.registerNametag(options.nametag);
-    }
-
-    // Auto-discover previously used HD addresses
-    if (options.discoverAddresses !== false && sphere._transport.discoverAddresses) {
-      progress?.({ step: 'discovering_addresses', message: 'Discovering addresses...' });
-      try {
-        const discoverOpts: DiscoverAddressesOptions =
-          typeof options.discoverAddresses === 'object'
-            ? { ...options.discoverAddresses, autoTrack: options.discoverAddresses.autoTrack ?? true }
-            : { autoTrack: true };
-        const result = await sphere.discoverAddresses(discoverOpts);
-        if (result.addresses.length > 0) {
-          logger.debug('Sphere', `Address discovery: found ${result.addresses.length} address(es)`);
-        }
-      } catch (err) {
-        logger.warn('Sphere', 'Address discovery failed (non-fatal):', err);
+      // Register nametag if provided (this overrides any recovered nametag)
+      if (options.nametag) {
+        progress?.({ step: 'registering_nametag', message: 'Registering nametag...' });
+        logger.debug('Sphere', 'Registering Unicity ID...');
+        await sphere.registerNametag(options.nametag);
       }
-    }
 
-    progress?.({ step: 'complete', message: 'Import complete' });
-    logger.debug('Sphere', 'Import complete');
+      // Auto-discover previously used HD addresses
+      if (options.discoverAddresses !== false && sphere._transport.discoverAddresses) {
+        progress?.({ step: 'discovering_addresses', message: 'Discovering addresses...' });
+        try {
+          const discoverOpts: DiscoverAddressesOptions =
+            typeof options.discoverAddresses === 'object'
+              ? { ...options.discoverAddresses, autoTrack: options.discoverAddresses.autoTrack ?? true }
+              : { autoTrack: true };
+          const result = await sphere.discoverAddresses(discoverOpts);
+          if (result.addresses.length > 0) {
+            logger.debug('Sphere', `Address discovery: found ${result.addresses.length} address(es)`);
+          }
+        } catch (err) {
+          logger.warn('Sphere', 'Address discovery failed (non-fatal):', err);
+        }
+      }
+
+      progress?.({ step: 'complete', message: 'Import complete' });
+      logger.debug('Sphere', 'Import complete');
+    });
+
+    Sphere.instance = sphere;
     return sphere;
   }
 

--- a/core/Sphere.ts
+++ b/core/Sphere.ts
@@ -823,8 +823,13 @@ export class Sphere {
     try {
       await bringUp();
     } catch (err) {
-      sphere._registry?.dispose();
-      sphere._registry = null;
+      // Tear down the WHOLE half-built Sphere, not just its registry. By this point
+      // providers may be connected and the payments vertical running, and publication
+      // happens AFTER this guard — so the caller receives nothing that could destroy
+      // them. destroy() disposes the registry as its first act, so this subsumes it.
+      await sphere.destroy().catch((teardownErr) => {
+        logger.warn('Sphere', 'teardown after failed initialization also failed:', teardownErr);
+      });
       throw err;
     }
   }

--- a/core/payments-v2-wiring.ts
+++ b/core/payments-v2-wiring.ts
@@ -20,7 +20,7 @@ import type { PeerInfo } from '../transport';
 import type { StorageProvider } from '../storage';
 import type { PriceProvider } from '../price';
 import type { ITokenEngine } from '../token-engine/engine';
-import { TokenRegistry } from '../registry';
+import type { RegistryReader } from '../modules/payments-v2/inventory/presentation';
 import {
   PaymentsFacade,
   type FacadeClient,
@@ -242,6 +242,7 @@ export function authedWireClient(session: WalletApiSession, client: WalletApiV2C
 export interface PaymentsV2Host {
   storage: StorageProvider;
   price: PriceProvider | null;
+  registry: RegistryReader;
   /** The Sphere event bus (`emitEvent`) — the facade's 8 events ride it directly. */
   emit: (event: string, payload: unknown) => void;
   /** Transport resolve — the same lookup the old send path used. */
@@ -334,7 +335,7 @@ export function composePaymentsV2(spec: ComposePaymentsV2Spec): PaymentsFacade {
     }),
     engineRef: spec.engineRef,
     kv,
-    registry: TokenRegistry.getInstance(),
+    registry: host.registry,
     ...(host.price !== null ? { price: host.price } : {}),
     emit: host.emit,
     resolveRecipient: (identifier) => resolveRecipientInfo(identifier, network, host.resolvePeer),

--- a/docs/MIGRATION-TOKEN-REGISTRY.md
+++ b/docs/MIGRATION-TOKEN-REGISTRY.md
@@ -1,0 +1,100 @@
+# Migration: the token registry becomes per-Sphere
+
+Tracking issue: [#766](https://github.com/unicity-sphere/sphere-sdk/issues/766)
+
+## Why
+
+`TokenRegistry` is a process-global singleton, and `TokenRegistry.configure()` reaches into
+whatever instance exists and repoints it. Every `Sphere.init()` calls it. So a second Sphere
+silently rewrites the first one's metadata.
+
+Reproduced, with two Spheres on **separate storage providers**:
+
+```
+instance #1 (testnet2), reading its own asset
+  BEFORE the mainnet init:  { symbol: 'TCOIN', name: 'TestnetCoin', decimals: 8 }
+  AFTER  the mainnet init:  { symbol: 'AAAAAA', name: 'aaaa…aa',    decimals: 0 }
+```
+
+`AAAAAA` is `coinId.slice(0, 6).toUpperCase()` and `0` is `decimals ?? 0` — the registry-miss
+fallbacks. Nothing on instance #1 restores it: not `switchToAddress`, not `setOracleApiKey`.
+
+Inside the SDK this is presentation only — the money path treats `coinId` as opaque bytes,
+`mint()` rejects non-hex, and coin selection byte-compares. **At the consumer boundary it is
+not.** Code that reads `decimals` from the registry and feeds it to `parseTokenAmount()`, or
+reads a `coinId` from the registry and passes it to `send()`/`mint()`, gets a 10ⁿ scale error
+or the wrong coin. Check your own call sites for that shape.
+
+Separately, `Sphere.destroy()` never touched the registry, so every discarded Sphere left an
+hourly fetch running. Nothing in `registry/` calls `unref()`, so under Node that also keeps the
+event loop alive.
+
+## What changed in this release
+
+- **A `Sphere` now builds and owns its own registry**, and the payments facade presents from
+  that one instead of the global. Two Spheres on different networks no longer disturb each
+  other's metadata.
+- **`Sphere.destroy()` disposes that registry** — timer stopped, no late apply, no late cache
+  write. The process-global is deliberately left running, because other code still reads it.
+- **`TokenRegistry.create(options)`** builds an independent registry; **`dispose()`**,
+  **`isDisposed`** and an instance-level **`waitForReady()`** are new.
+- **`createBrowserProviders` / `createNodeProviders` no longer call `TokenRegistry.configure()`.**
+- The ten singleton-bound free functions moved to `registry/global-readers.ts`. They are
+  re-exported unchanged; no import path changes.
+
+The public surface is otherwise identical — same 126 root exports, same names, same signatures.
+
+## Do you need to change anything?
+
+**Almost certainly not.** One case to check:
+
+> Do you call `createBrowserProviders()` or `createNodeProviders()` and then read the registry,
+> **without** calling `Sphere.init()`?
+
+If yes, configure it yourself:
+
+```ts
+import { TokenRegistry, NETWORKS } from '@unicitylabs/sphere-sdk';
+
+TokenRegistry.configure({
+  remoteUrl: NETWORKS[network].tokenRegistryUrl,
+  storage: providers.storage,
+});
+```
+
+If you call `Sphere.init()` — which configures the global exactly as before — nothing changes.
+
+Note this only ever worked when you imported `TokenRegistry` and the provider factory from the
+**same** entry point. In the published package they are separate bundles with separate copies
+(`tsup` inlines `registry/` into each entry and sets `splitting: false`), so the factories'
+`configure()` call was writing to an object no consumer could read. Removing it is a no-op for
+anyone consuming the published package.
+
+## Preparing for what comes next
+
+The global is going away. When it does, `TokenRegistry.getInstance()`, `configure()`,
+`resetInstance()`, `destroy()`, the static `waitForReady()` and the ten free functions go with
+it, and reads move to the registry your Sphere owns.
+
+You can get ahead of it now:
+
+- **Prefer per-Sphere reads over global reads** for anything network-sensitive — above all
+  anywhere a `coinId` or `decimals` from the registry reaches `send()`, `mint()` or an amount
+  conversion. Those are the sites where a retargeted registry is a money bug rather than a
+  cosmetic one.
+- **Don't rely on `getInstance()` in module-scope initialisers.** A module-scope capture binds
+  to whichever network configured the global first, which is the bug in miniature.
+- **Test teardown that calls `TokenRegistry.resetInstance()`** to stop the background timer can
+  eventually drop it: a Sphere-owned registry is disposed by `sphere.destroy()`.
+
+Nothing above is required in this release. It is what will make the removal a small change
+rather than a large one.
+
+## Not fixed by this release
+
+`Sphere` still holds a process-global `static instance`, so `Sphere.getInstance()` and
+`isInitialized()` describe whichever Sphere was created last, and `Sphere.clear()` /
+`Sphere.import()` destroy whichever instance holds that static **regardless of which storage
+they were given**. Two `FileStorageProvider`s pointed at one `dataDir` also clobber each
+other's wallet file. Those are tracked in [#766](https://github.com/unicity-sphere/sphere-sdk/issues/766)
+and are the remainder of "create new ones at the same time".

--- a/docs/QUICKSTART-BROWSER.md
+++ b/docs/QUICKSTART-BROWSER.md
@@ -391,7 +391,12 @@ console.log(uct?.name, uct?.decimals);  // 'Unicity Token', 8
 const coinId = registry.getCoinIdBySymbol('UCT');
 ```
 
-> **Note:** The registry is configured automatically by `createBrowserProviders()` and `Sphere.init()`. Data is fetched from the network and cached in `localStorage`.
+> **Note:** The registry is configured automatically by `Sphere.init()`. `createBrowserProviders()` does **not** configure it — if you build providers without initialising a Sphere and then read the registry directly, configure it yourself:
+>
+> ```ts
+> TokenRegistry.configure({ remoteUrl: NETWORKS[network].tokenRegistryUrl, storage: providers.storage });
+> ```
+> Data is fetched from the network and cached in `localStorage`.
 
 ### Send Tokens
 

--- a/docs/QUICKSTART-BROWSER.md
+++ b/docs/QUICKSTART-BROWSER.md
@@ -394,7 +394,12 @@ const coinId = registry.getCoinIdBySymbol('UCT');
 > **Note:** The registry is configured automatically by `Sphere.init()`. `createBrowserProviders()` does **not** configure it — if you build providers without initialising a Sphere and then read the registry directly, configure it yourself:
 >
 > ```ts
-> TokenRegistry.configure({ remoteUrl: NETWORKS[network].tokenRegistryUrl, storage: providers.storage });
+> import { TokenRegistry, NETWORKS } from '@unicitylabs/sphere-sdk';
+>
+> TokenRegistry.configure({
+>   remoteUrl: NETWORKS.testnet2.tokenRegistryUrl,
+>   storage: providers.storage,
+> });
 > ```
 > Data is fetched from the network and cached in `localStorage`.
 

--- a/docs/QUICKSTART-NODEJS.md
+++ b/docs/QUICKSTART-NODEJS.md
@@ -322,7 +322,12 @@ console.log(uct?.name, uct?.decimals);  // 'Unicity Token', 8
 const coinId = registry.getCoinIdBySymbol('UCT');
 ```
 
-> **Note:** The registry is configured automatically by `createNodeProviders()` and `Sphere.init()`. Data is fetched from the network and cached to disk.
+> **Note:** The registry is configured automatically by `Sphere.init()`. `createNodeProviders()` does **not** configure it — if you build providers without initialising a Sphere and then read the registry directly, configure it yourself:
+>
+> ```ts
+> TokenRegistry.configure({ remoteUrl: NETWORKS[network].tokenRegistryUrl, storage: providers.storage });
+> ```
+> Data is fetched from the network and cached to disk.
 
 ### Send Tokens
 

--- a/docs/QUICKSTART-NODEJS.md
+++ b/docs/QUICKSTART-NODEJS.md
@@ -325,7 +325,12 @@ const coinId = registry.getCoinIdBySymbol('UCT');
 > **Note:** The registry is configured automatically by `Sphere.init()`. `createNodeProviders()` does **not** configure it — if you build providers without initialising a Sphere and then read the registry directly, configure it yourself:
 >
 > ```ts
-> TokenRegistry.configure({ remoteUrl: NETWORKS[network].tokenRegistryUrl, storage: providers.storage });
+> import { TokenRegistry, NETWORKS } from '@unicitylabs/sphere-sdk';
+>
+> TokenRegistry.configure({
+>   remoteUrl: NETWORKS.testnet2.tokenRegistryUrl,
+>   storage: providers.storage,
+> });
 > ```
 > Data is fetched from the network and cached to disk.
 

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -293,9 +293,6 @@
     },
     "complexity": {
       "count": 1
-    },
-    "max-lines-per-function": {
-      "count": 1
     }
   },
   "impl/browser/oracle/index.ts": {

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -122,7 +122,7 @@
       "count": 2
     },
     "complexity": {
-      "count": 9
+      "count": 6
     },
     "max-depth": {
       "count": 8

--- a/impl/browser/index.ts
+++ b/impl/browser/index.ts
@@ -43,7 +43,6 @@ import type { GroupChatModuleConfig } from '../../modules/groupchat';
 import type { MarketModuleConfig } from '../../modules/market';
 import type { PriceProvider } from '../../price';
 import { createPriceProvider } from '../../price';
-import { TokenRegistry } from '../../registry';
 import {
   type BaseTransportConfig,
   type BaseOracleConfig,
@@ -53,7 +52,6 @@ import {
   resolveTransportConfig,
   resolveOracleConfig,
   resolvePriceConfig,
-  getNetworkConfig,
   resolveGroupChatConfig,
   resolveMarketConfig,
 } from '../shared';
@@ -196,10 +194,6 @@ export function createBrowserProviders(config?: BrowserProvidersConfig): Browser
 
   // Resolve market config
   const market = resolveMarketConfig(config?.market);
-
-  // Configure token registry remote refresh with persistent cache
-  const networkConfig = getNetworkConfig(network);
-  TokenRegistry.configure({ remoteUrl: networkConfig.tokenRegistryUrl, storage });
 
   return {
     storage,

--- a/impl/nodejs/index.ts
+++ b/impl/nodejs/index.ts
@@ -37,7 +37,6 @@ import type { TransportProvider } from '../../transport';
 import type { OracleProvider } from '../../oracle';
 import type { PriceProvider } from '../../price';
 import { createPriceProvider } from '../../price';
-import { TokenRegistry } from '../../registry';
 import type { NetworkType } from '../../constants';
 import type { GroupChatModuleConfig } from '../../modules/groupchat';
 import type { MarketModuleConfig } from '../../modules/market';
@@ -52,8 +51,7 @@ import {
   resolvePriceConfig,
   resolveGroupChatConfig,
   resolveMarketConfig,
-  getNetworkConfig,
-} from '../shared';
+  } from '../shared';
 
 // =============================================================================
 // Node.js-Specific Configuration Extensions
@@ -196,10 +194,6 @@ export function createNodeProviders(config?: NodeProvidersConfig): NodeProviders
 
   // Resolve market config
   const market = resolveMarketConfig(config?.market);
-
-  // Configure token registry remote refresh with persistent cache
-  const networkConfig = getNetworkConfig(network);
-  TokenRegistry.configure({ remoteUrl: networkConfig.tokenRegistryUrl, storage });
 
   return {
     storage,

--- a/registry/TokenRegistry.ts
+++ b/registry/TokenRegistry.ts
@@ -119,6 +119,8 @@ export class TokenRegistry {
   private generation = 0;
   /** Set by dispose(). A disposed registry starts no work and applies no late result. */
   private disposed = false;
+  /** Cancels the in-flight fetch (and its abort timer) when the registry is disposed. */
+  private inFlight: { abort: () => void } | null = null;
 
   private constructor() {
     this.definitionsById = new Map();
@@ -213,6 +215,9 @@ export class TokenRegistry {
     if (this.disposed) return;
     this.disposed = true;
     this.stopAutoRefresh();
+    // Cancel any request already in the air, not just future ones.
+    this.inFlight?.abort();
+    this.inFlight = null;
     // Any in-flight load belongs to a generation that no longer exists.
     this.generation++;
     this.refreshPromise = null;
@@ -455,6 +460,33 @@ export class TokenRegistry {
     }
   }
 
+  /**
+   * Fetch with a bounded timeout, exposing a cancel hook to dispose().
+   *
+   * Both the request and its abort timer keep Node's event loop alive for the full
+   * FETCH_TIMEOUT_MS, so a registry disposed mid-flight must cancel them rather than
+   * merely ignore the result.
+   */
+  private async fetchCancellable(url: string): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    this.inFlight = {
+      abort: () => {
+        clearTimeout(timer);
+        controller.abort();
+      },
+    };
+    try {
+      return await fetch(url, {
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+      this.inFlight = null;
+    }
+  }
+
   private async doRefresh(): Promise<boolean> {
     // Pin the url and generation for this attempt. configure() may swap networks while the
     // fetch is in flight; applying or caching the result afterwards would reinstate the old
@@ -462,18 +494,7 @@ export class TokenRegistry {
     const url = this.remoteUrl!;
     const gen = this.generation;
     try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-      let response: Response;
-      try {
-        response = await fetch(url, {
-          headers: { Accept: 'application/json' },
-          signal: controller.signal,
-        });
-      } finally {
-        clearTimeout(timer);
-      }
+      const response = await this.fetchCancellable(url);
 
       if (!response.ok) {
         logger.warn('TokenRegistry', `Remote fetch failed: HTTP ${response.status} ${response.statusText}`);

--- a/registry/TokenRegistry.ts
+++ b/registry/TokenRegistry.ts
@@ -232,10 +232,20 @@ export class TokenRegistry {
     if (timeoutMs <= 0) {
       return this.initialLoadPromise;
     }
-    return Promise.race([
-      this.initialLoadPromise,
-      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
-    ]);
+    // Clear the losing timer: a race leaves it scheduled, and an unreferenced timeout
+    // still holds Node's event loop open for its full duration — here up to 10s after
+    // the registry has been disposed.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        this.initialLoadPromise,
+        new Promise<boolean>((resolve) => {
+          timer = setTimeout(() => resolve(false), timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
   }
 
   /**
@@ -263,17 +273,7 @@ export class TokenRegistry {
    * @param timeoutMs - Maximum wait time in ms (default: 10s). Set to 0 for no timeout.
    */
   static async waitForReady(timeoutMs: number = 10_000): Promise<boolean> {
-    const instance = TokenRegistry.getInstance();
-    if (!instance.initialLoadPromise) {
-      return instance.definitionsById.size > 0;
-    }
-    if (timeoutMs <= 0) {
-      return instance.initialLoadPromise;
-    }
-    return Promise.race([
-      instance.initialLoadPromise,
-      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
-    ]);
+    return TokenRegistry.getInstance().waitForReady(timeoutMs);
   }
 
   // ===========================================================================

--- a/registry/TokenRegistry.ts
+++ b/registry/TokenRegistry.ts
@@ -303,6 +303,9 @@ export class TokenRegistry {
     // Step 2: Cache miss — wait for first remote fetch (only when auto-refresh is enabled)
     if (autoRefresh && this.remoteUrl) {
       loaded = await this.refreshFromRemote();
+      // Re-check: dispose() may have run during the await, and the entry guard above no
+      // longer holds. Arming here would outlive the owner that asked to be torn down.
+      if (this.disposed) return loaded;
       // Start periodic refresh (skip immediate since we just fetched)
       this.stopAutoRefresh();
       this.refreshTimer = setInterval(() => {
@@ -509,6 +512,9 @@ export class TokenRegistry {
    * Does an immediate fetch, then repeats at the configured interval.
    */
   startAutoRefresh(intervalMs?: number): void {
+    // A disposed registry must never hold an interval. The callback would no-op via the
+    // disposed guard, but the TIMER ITSELF is the leak — it keeps Node's loop alive.
+    if (this.disposed) return;
     this.stopAutoRefresh();
 
     if (intervalMs !== undefined) {

--- a/registry/TokenRegistry.ts
+++ b/registry/TokenRegistry.ts
@@ -117,6 +117,8 @@ export class TokenRegistry {
   private initialLoadPromise: Promise<boolean> | null = null;
   /** Bumped on every remoteUrl change; loads started in an older generation are discarded. */
   private generation = 0;
+  /** Set by dispose(). A disposed registry starts no work and applies no late result. */
+  private disposed = false;
 
   private constructor() {
     this.definitionsById = new Map();
@@ -148,7 +150,26 @@ export class TokenRegistry {
    * @param options.autoRefresh - Start auto-refresh immediately (default: true)
    */
   static configure(options: TokenRegistryConfig): void {
-    const instance = TokenRegistry.getInstance();
+    TokenRegistry.getInstance().applyConfig(options);
+  }
+
+  /**
+   * Create an INDEPENDENT registry, not the process-global singleton.
+   *
+   * One Sphere owns one of these, so two Spheres on different networks cannot wipe each
+   * other's definitions — the singleton's `configure()` reaches into whatever instance
+   * exists and repoints it, which is how a mainnet init silently retargeted a live
+   * testnet2 wallet's decimals. Dispose it when the owner is destroyed.
+   */
+  static create(options: TokenRegistryConfig): TokenRegistry {
+    const registry = new TokenRegistry();
+    registry.applyConfig(options);
+    return registry;
+  }
+
+  /** The body of configure(), on the instance, so owned registries share it exactly. */
+  private applyConfig(options: TokenRegistryConfig): void {
+    if (this.disposed) return;
 
     if (options.remoteUrl !== undefined) {
       // A network switch must not leave the old network's definitions resolvable:
@@ -156,29 +177,65 @@ export class TokenRegistry {
       // failed load would keep serving foreign coinIds — wrong decimals, silently.
       // lastRefreshAt resets too, else loadFromCache refuses the new network's snapshot
       // as older than the stale timestamp.
-      const previous = instance.remoteUrl;
+      const previous = this.remoteUrl;
       if (previous && previous !== options.remoteUrl) {
-        instance.applyDefinitions([]);
-        instance.lastRefreshAt = 0;
+        this.applyDefinitions([]);
+        this.lastRefreshAt = 0;
         // Abandon any in-flight load: it fetched the OLD url, so its result must neither
         // be applied nor cached, and the next caller must not dedupe onto it.
-        instance.generation++;
-        instance.refreshPromise = null;
+        this.generation++;
+        this.refreshPromise = null;
       }
-      instance.remoteUrl = options.remoteUrl;
+      this.remoteUrl = options.remoteUrl;
     }
     if (options.storage !== undefined) {
-      instance.storage = options.storage;
+      this.storage = options.storage;
     }
     if (options.refreshIntervalMs !== undefined) {
-      instance.refreshIntervalMs = options.refreshIntervalMs;
+      this.refreshIntervalMs = options.refreshIntervalMs;
     }
 
     const autoRefresh = options.autoRefresh ?? true;
 
     // Perform initial load (cache → remote fallback) and store the promise
     // so consumers can await readiness via TokenRegistry.waitForReady()
-    instance.initialLoadPromise = instance.performInitialLoad(autoRefresh);
+    this.initialLoadPromise = this.performInitialLoad(autoRefresh);
+  }
+
+  /**
+   * Stop this registry for good: no timer, no late apply, no late cache write.
+   *
+   * Sphere.destroy() calls this on the registry it owns. Without it a discarded Sphere
+   * leaves an hourly fetch running forever — nothing in this file calls unref(), so in
+   * Node it also keeps the event loop alive.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.stopAutoRefresh();
+    // Any in-flight load belongs to a generation that no longer exists.
+    this.generation++;
+    this.refreshPromise = null;
+    this.initialLoadPromise = null;
+  }
+
+  /** Whether dispose() has been called. Reads still work; they are simply frozen. */
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  /** Per-instance readiness — the same contract as the static, for an owned registry. */
+  async waitForReady(timeoutMs: number = 10_000): Promise<boolean> {
+    if (!this.initialLoadPromise) {
+      return this.definitionsById.size > 0;
+    }
+    if (timeoutMs <= 0) {
+      return this.initialLoadPromise;
+    }
+    return Promise.race([
+      this.initialLoadPromise,
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
+    ]);
   }
 
   /**
@@ -228,6 +285,7 @@ export class TokenRegistry {
    * After initial data is available, start periodic auto-refresh if configured.
    */
   private async performInitialLoad(autoRefresh: boolean): Promise<boolean> {
+    if (this.disposed) return false;
     // Step 1: Try loading from cache
     let loaded = false;
     if (this.storage) {
@@ -372,7 +430,7 @@ export class TokenRegistry {
    * Concurrent calls are deduplicated — only one fetch runs at a time.
    */
   async refreshFromRemote(): Promise<boolean> {
-    if (!this.remoteUrl) {
+    if (this.disposed || !this.remoteUrl) {
       return false;
     }
 
@@ -626,138 +684,4 @@ export class TokenRegistry {
     const def = this.getDefinitionByName(name);
     return def?.id;
   }
-}
-
-// =============================================================================
-// Convenience Functions
-// =============================================================================
-
-/**
- * Get token definition by coin ID
- * @param coinId - 64-character hex string
- * @returns Token definition or undefined
- */
-export function getTokenDefinition(coinId: string): TokenDefinition | undefined {
-  return TokenRegistry.getInstance().getDefinition(coinId);
-}
-
-/**
- * Get token symbol by coin ID
- * @param coinId - 64-character hex string
- * @returns Symbol or truncated ID
- */
-export function getTokenSymbol(coinId: string): string {
-  return TokenRegistry.getInstance().getSymbol(coinId);
-}
-
-/**
- * Get token name by coin ID
- * @param coinId - 64-character hex string
- * @returns Name or coin ID
- */
-export function getTokenName(coinId: string): string {
-  return TokenRegistry.getInstance().getName(coinId);
-}
-
-/**
- * Get token decimals by coin ID
- * @param coinId - 64-character hex string
- * @returns Decimals or 0
- */
-export function getTokenDecimals(coinId: string): number {
-  return TokenRegistry.getInstance().getDecimals(coinId);
-}
-
-/**
- * Get token icon URL by coin ID
- * @param coinId - 64-character hex string
- * @param preferPng - Prefer PNG over SVG
- * @returns Icon URL or null
- */
-export function getTokenIconUrl(coinId: string, preferPng = true): string | null {
-  return TokenRegistry.getInstance().getIconUrl(coinId, preferPng);
-}
-
-/**
- * Check if coin ID is in registry
- * @param coinId - 64-character hex string
- * @returns true if known
- */
-export function isKnownToken(coinId: string): boolean {
-  return TokenRegistry.getInstance().isKnown(coinId);
-}
-
-/**
- * Get coin ID by symbol
- * @param symbol - Token symbol (e.g., "UCT")
- * @returns Coin ID or undefined
- */
-export function getCoinIdBySymbol(symbol: string): string | undefined {
-  return TokenRegistry.getInstance().getCoinIdBySymbol(symbol);
-}
-
-/**
- * Get coin ID by name
- * @param name - Token name (e.g., "bitcoin")
- * @returns Coin ID or undefined
- */
-export function getCoinIdByName(name: string): string | undefined {
-  return TokenRegistry.getInstance().getCoinIdByName(name);
-}
-
-/**
- * Normalize a coin identifier to its canonical hash coinId.
- *
- * Accepts both symbolic names ("BTC", "ETH") and hash coinIds (64-char hex).
- * If the input is a short symbol, resolves it via the TokenRegistry.
- * Returns the input unchanged if it's already a hash coinId or unknown.
- *
- * @public
- *
- * @remarks
- * Heuristic: inputs matching `length <= 20 && /^[A-Za-z0-9]+$/` are treated
- * as symbolic names and looked up in the registry. Long inputs, hyphenated
- * inputs ("TOKEN-123"), or dotted inputs ("BTC.CASH") pass through unchanged.
- *
- * **Stability:** This function depends on `TokenRegistry` content. Adding a
- * new symbol that shadows a previously-unknown short alphanumeric coinId
- * changes normalization semantics retroactively. Consumers building stable
- * keys against this output should be aware that registry growth is a
- * non-breaking change *for unknown inputs* but a breaking change *for inputs
- * that newly resolve*.
- *
- * @param coinId - A symbolic name or hash coinId.
- * @returns The canonical hash coinId, or the original string if not resolvable.
- */
-export function normalizeCoinId(coinId: string): string {
-  // Short alphanumeric strings are likely symbolic names (BTC, ETH, USDU, etc.)
-  if (coinId.length <= 20 && /^[A-Za-z0-9]+$/.test(coinId)) {
-    const resolved = getCoinIdBySymbol(coinId);
-    if (resolved) return resolved;
-  }
-  return coinId;
-}
-
-/**
- * Compare two coin identifiers for equality, normalizing both sides.
- *
- * Handles mixed-format comparisons: "BTC" vs hash coinId, or two hash coinIds.
- * Both values are normalized to hash coinIds via the TokenRegistry before comparison.
- *
- * @public
- *
- * @remarks
- * Reflexive byte-equality short-circuit comes first; otherwise both sides
- * are normalized via {@link normalizeCoinId} and compared. Inherits the
- * registry-dependence caveat from `normalizeCoinId`. Two distinct symbols
- * that both fail to resolve will compare unequal even if they're semantic
- * aliases — register them as aliases in `TokenRegistry` for matching.
- *
- * @param a - First coin identifier (symbol or hash coinId).
- * @param b - Second coin identifier (symbol or hash coinId).
- * @returns true if both resolve to the same canonical coinId.
- */
-export function coinIdsMatch(a: string, b: string): boolean {
-  if (a === b) return true;
-  return normalizeCoinId(a) === normalizeCoinId(b);
 }

--- a/registry/global-readers.ts
+++ b/registry/global-readers.ts
@@ -1,0 +1,53 @@
+/**
+ * Readers bound to the PROCESS-GLOBAL registry: with two Spheres alive they answer for
+ * whichever network configured it last. Prefer a Sphere-owned registry when it matters.
+ */
+
+import { TokenRegistry } from './TokenRegistry';
+import type { TokenDefinition } from './TokenRegistry';
+
+export function getTokenDefinition(coinId: string): TokenDefinition | undefined {
+  return TokenRegistry.getInstance().getDefinition(coinId);
+}
+
+export function getTokenSymbol(coinId: string): string {
+  return TokenRegistry.getInstance().getSymbol(coinId);
+}
+
+export function getTokenName(coinId: string): string {
+  return TokenRegistry.getInstance().getName(coinId);
+}
+
+export function getTokenDecimals(coinId: string): number {
+  return TokenRegistry.getInstance().getDecimals(coinId);
+}
+
+export function getTokenIconUrl(coinId: string, preferPng = true): string | null {
+  return TokenRegistry.getInstance().getIconUrl(coinId, preferPng);
+}
+
+export function isKnownToken(coinId: string): boolean {
+  return TokenRegistry.getInstance().isKnown(coinId);
+}
+
+export function getCoinIdBySymbol(symbol: string): string | undefined {
+  return TokenRegistry.getInstance().getCoinIdBySymbol(symbol);
+}
+
+export function getCoinIdByName(name: string): string | undefined {
+  return TokenRegistry.getInstance().getCoinIdByName(name);
+}
+
+export function normalizeCoinId(coinId: string): string {
+  // Short alphanumeric strings are likely symbolic names (BTC, ETH, USDU, etc.)
+  if (coinId.length <= 20 && /^[A-Za-z0-9]+$/.test(coinId)) {
+    const resolved = getCoinIdBySymbol(coinId);
+    if (resolved) return resolved;
+  }
+  return coinId;
+}
+
+export function coinIdsMatch(a: string, b: string): boolean {
+  if (a === b) return true;
+  return normalizeCoinId(a) === normalizeCoinId(b);
+}

--- a/registry/index.ts
+++ b/registry/index.ts
@@ -13,6 +13,10 @@ export {
   type RegistryNetwork,
   type TokenRegistryConfig,
   // Convenience functions
+} from './TokenRegistry';
+
+// Singleton-bound convenience readers (see global-readers.ts).
+export {
   getTokenDefinition,
   getTokenSymbol,
   getTokenName,
@@ -23,4 +27,4 @@ export {
   getCoinIdByName,
   normalizeCoinId,
   coinIdsMatch,
-} from './TokenRegistry';
+} from './global-readers';

--- a/tests/integration/sphere-payments-v2-wiring.test.ts
+++ b/tests/integration/sphere-payments-v2-wiring.test.ts
@@ -25,6 +25,7 @@ import { getPublicKey, hexToBytes } from '../../core/crypto';
 import { decryptDeliveryBundle, deriveDeliveryEncryptionKey } from '../../core/delivery-envelope';
 import { FileStorageProvider } from '../../impl/nodejs/storage/FileStorageProvider';
 import { TRUSTBASE_TESTNET2 } from '../../assets/trustbase';
+import { TokenRegistry } from '../../registry';
 import type { PeerInfo, TransportProvider } from '../../transport';
 import type { OracleProvider } from '../../oracle';
 import type { ProviderStatus } from '../../types';
@@ -217,6 +218,42 @@ async function buildSphere(options: BuildOptions): Promise<Sphere> {
   });
   return sphere;
 }
+
+describe('Sphere payments wiring — the token registry is OWNED, not the process global', () => {
+  // #766: the global's configure() is repointed by every other Sphere's init, which is how
+  // a mainnet init silently flipped a live testnet2 wallet's decimals to 0. A Sphere must
+  // build and hold its own, and must stop it on destroy — nothing in registry/ calls
+  // unref(), so a surviving interval outlives the wallet and keeps Node's loop alive.
+  it('builds its own registry on init and disposes it on destroy', async () => {
+    const create = vi.spyOn(TokenRegistry, 'create');
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-'));
+    const storage = new FileStorageProvider({ dataDir });
+    try {
+      const { sphere } = await Sphere.init({
+        storage,
+        transport: createMockTransport(),
+        oracle: createEngineOracle(),
+        mnemonic: MNEMONIC,
+        network: NET,
+        walletApi: makeWorld().walletApi,
+      });
+
+      expect(create).toHaveBeenCalledTimes(1);
+      const owned = create.mock.results[0]!.value as TokenRegistry;
+      // It is a real instance, and NOT the process global.
+      expect(owned).not.toBe(TokenRegistry.getInstance());
+      expect(owned.isDisposed).toBe(false);
+
+      await sphere.destroy();
+      expect(owned.isDisposed).toBe(true);
+      // The global is deliberately left running — other code still reads it.
+      expect(TokenRegistry.getInstance().isDisposed).toBe(false);
+    } finally {
+      create.mockRestore();
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('Sphere payments wiring — defaults (P11 flip: the vertical is default and only)', () => {
   it('composing the vertical sweeps the superseded pv2: state left by a 2.x wallet', async () => {

--- a/tests/integration/sphere-payments-v2-wiring.test.ts
+++ b/tests/integration/sphere-payments-v2-wiring.test.ts
@@ -374,6 +374,40 @@ describe('Sphere payments wiring — the token registry is OWNED, not the proces
     }
   });
 
+  it('disposes the registry when the LAST init step rejects, after publication would have been', async () => {
+    // Publication used to happen mid-init, and the guard ended there on the premise that a
+    // published Sphere is recoverable via Sphere.getInstance(). That premise fails under
+    // concurrent inits — a second one overwrites the static — so the guard now runs to the
+    // end and publication is the last thing before the return. 'complete' is the final
+    // progress step in create(), so a throw here is past every other fallible operation.
+    const create = vi.spyOn(TokenRegistry, 'create');
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-last-'));
+    const storage = new FileStorageProvider({ dataDir });
+    try {
+      await expect(
+        Sphere.init({
+          storage,
+          transport: createMockTransport(),
+          oracle: createEngineOracle(),
+          mnemonic: MNEMONIC,
+          network: NET,
+          walletApi: makeWorld().walletApi,
+          onProgress: (p: { step: string }) => {
+            if (p.step === 'complete') throw new Error('progress callback exploded at the end');
+          },
+        })
+      ).rejects.toThrow();
+
+      expect(create).toHaveBeenCalledTimes(1);
+      expect((create.mock.results[0]!.value as TokenRegistry).isDisposed).toBe(true);
+      // And the failed init published nothing, so no half-built Sphere is reachable.
+      expect(Sphere.getInstance()).toBeNull();
+    } finally {
+      create.mockRestore();
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it('destroy() disposes the registry even when teardown throws', async () => {
     const create = vi.spyOn(TokenRegistry, 'create');
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-throw-'));

--- a/tests/integration/sphere-payments-v2-wiring.test.ts
+++ b/tests/integration/sphere-payments-v2-wiring.test.ts
@@ -313,6 +313,36 @@ describe('Sphere payments wiring — the token registry is OWNED, not the proces
     }
   });
 
+  it('disposes the registry when MODULE bring-up rejects, not just provider bring-up', async () => {
+    // Guarding only initializeProviders was not enough: initializeModules runs after it and
+    // is fallible too. An oracle that connects but exposes no trust base makes
+    // buildTokenEngine return undefined, and startPaymentsV2Inner then throws INVALID_CONFIG
+    // — past the provider guard, with the registry already built.
+    const create = vi.spyOn(TokenRegistry, 'create');
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-modules-'));
+    const storage = new FileStorageProvider({ dataDir });
+    const oracle = createEngineOracle();
+    (oracle as unknown as { getTrustBaseJson: () => unknown }).getTrustBaseJson = () => null;
+    try {
+      await expect(
+        Sphere.init({
+          storage,
+          transport: createMockTransport(),
+          oracle,
+          mnemonic: MNEMONIC,
+          network: NET,
+          walletApi: makeWorld().walletApi,
+        })
+      ).rejects.toThrow();
+
+      expect(create).toHaveBeenCalledTimes(1);
+      expect((create.mock.results[0]!.value as TokenRegistry).isDisposed).toBe(true);
+    } finally {
+      create.mockRestore();
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it('destroy() disposes the registry even when teardown throws', async () => {
     const create = vi.spyOn(TokenRegistry, 'create');
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-throw-'));

--- a/tests/integration/sphere-payments-v2-wiring.test.ts
+++ b/tests/integration/sphere-payments-v2-wiring.test.ts
@@ -254,12 +254,9 @@ describe('Sphere payments wiring — the token registry is OWNED, not the proces
     }
   });
 
-  it('an init that REJECTS leaves no registry behind', async () => {
-    // The registry is built late, after the fallible validation. Built early, a rejected
-    // mnemonic would strand an unreachable registry fetching hourly with no owner to
-    // destroy it — the caller never receives a Sphere.
+  it('never builds a registry when init rejects BEFORE provider bring-up', async () => {
     const create = vi.spyOn(TokenRegistry, 'create');
-    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-fail-'));
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-early-'));
     const storage = new FileStorageProvider({ dataDir });
     try {
       await expect(
@@ -273,10 +270,43 @@ describe('Sphere payments wiring — the token registry is OWNED, not the proces
         })
       ).rejects.toMatchObject({ code: 'INVALID_IDENTITY' });
 
-      // Either never built, or built and disposed — never left running.
-      for (const r of create.mock.results) {
-        expect((r.value as TokenRegistry).isDisposed).toBe(true);
-      }
+      // Built late, so a rejection this early never creates one at all.
+      expect(create).not.toHaveBeenCalled();
+    } finally {
+      create.mockRestore();
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('disposes the registry when provider bring-up itself rejects', async () => {
+    // The case the previous test CANNOT reach: the registry is built, and then init
+    // fails. Without cleanup it is stranded — the caller never receives a Sphere, so
+    // nothing can ever destroy it, and its hourly fetch runs for the life of the process.
+    const create = vi.spyOn(TokenRegistry, 'create');
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-late-'));
+    const storage = new FileStorageProvider({ dataDir });
+    const transport = createMockTransport();
+    (transport as unknown as { connect: ReturnType<typeof vi.fn> }).connect = vi
+      .fn()
+      .mockRejectedValue(new Error('transport refused to connect'));
+    (transport as unknown as { isConnected: ReturnType<typeof vi.fn> }).isConnected = vi
+      .fn()
+      .mockReturnValue(false);
+    try {
+      await expect(
+        Sphere.init({
+          storage,
+          transport,
+          oracle: createEngineOracle(),
+          mnemonic: MNEMONIC,
+          network: NET,
+          walletApi: makeWorld().walletApi,
+        })
+      ).rejects.toThrow();
+
+      expect(create).toHaveBeenCalledTimes(1);
+      const stranded = create.mock.results[0]!.value as TokenRegistry;
+      expect(stranded.isDisposed).toBe(true);
     } finally {
       create.mockRestore();
       fs.rmSync(dataDir, { recursive: true, force: true });

--- a/tests/integration/sphere-payments-v2-wiring.test.ts
+++ b/tests/integration/sphere-payments-v2-wiring.test.ts
@@ -414,6 +414,37 @@ describe('Sphere payments wiring — the token registry is OWNED, not the proces
     }
   });
 
+  it('destroy() keeps disconnecting after one teardown step rejects', async () => {
+    // The steps are independent resources. A transport disconnect that rejects must not
+    // skip storage and oracle — that is how a partial teardown failure leaves connections
+    // open, which is exactly the state the failed-init path calls destroy() in.
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-teardown-partial-'));
+    const storage = new FileStorageProvider({ dataDir });
+    const transport = createMockTransport();
+    const oracle = createEngineOracle();
+    try {
+      const { sphere } = await Sphere.init({
+        storage,
+        transport,
+        oracle,
+        mnemonic: MNEMONIC,
+        network: NET,
+        walletApi: makeWorld().walletApi,
+      });
+
+      vi.spyOn(transport, 'disconnect').mockRejectedValue(new Error('transport refused'));
+      const oracleDisconnect = vi.spyOn(oracle, 'disconnect');
+
+      await sphere.destroy().catch(() => undefined);
+
+      // The two steps AFTER the failing one still ran.
+      expect(storage.isConnected()).toBe(false);
+      expect(oracleDisconnect).toHaveBeenCalled();
+    } finally {
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it('destroy() disposes the registry even when teardown throws', async () => {
     const create = vi.spyOn(TokenRegistry, 'create');
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-throw-'));

--- a/tests/integration/sphere-payments-v2-wiring.test.ts
+++ b/tests/integration/sphere-payments-v2-wiring.test.ts
@@ -343,6 +343,37 @@ describe('Sphere payments wiring — the token registry is OWNED, not the proces
     }
   });
 
+  it('disposes the registry when a step AFTER module bring-up rejects', async () => {
+    // The guard now covers everything up to publication, not a named subset of steps.
+    // Twice I widened it one step and the next step along was still unguarded; this pins
+    // the far end — a failure at 'finalizing', after providers AND modules are up, still
+    // happens before Sphere.instance is assigned, so the caller gets nothing to destroy.
+    const create = vi.spyOn(TokenRegistry, 'create');
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-late2-'));
+    const storage = new FileStorageProvider({ dataDir });
+    try {
+      await expect(
+        Sphere.init({
+          storage,
+          transport: createMockTransport(),
+          oracle: createEngineOracle(),
+          mnemonic: MNEMONIC,
+          network: NET,
+          walletApi: makeWorld().walletApi,
+          onProgress: (p: { step: string }) => {
+            if (p.step === 'finalizing') throw new Error('progress callback exploded');
+          },
+        })
+      ).rejects.toThrow();
+
+      expect(create).toHaveBeenCalledTimes(1);
+      expect((create.mock.results[0]!.value as TokenRegistry).isDisposed).toBe(true);
+    } finally {
+      create.mockRestore();
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it('destroy() disposes the registry even when teardown throws', async () => {
     const create = vi.spyOn(TokenRegistry, 'create');
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-throw-'));

--- a/tests/integration/sphere-payments-v2-wiring.test.ts
+++ b/tests/integration/sphere-payments-v2-wiring.test.ts
@@ -383,11 +383,12 @@ describe('Sphere payments wiring — the token registry is OWNED, not the proces
     const create = vi.spyOn(TokenRegistry, 'create');
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-last-'));
     const storage = new FileStorageProvider({ dataDir });
+    const transport = createMockTransport();
     try {
       await expect(
         Sphere.init({
           storage,
-          transport: createMockTransport(),
+          transport,
           oracle: createEngineOracle(),
           mnemonic: MNEMONIC,
           network: NET,
@@ -402,6 +403,11 @@ describe('Sphere payments wiring — the token registry is OWNED, not the proces
       expect((create.mock.results[0]!.value as TokenRegistry).isDisposed).toBe(true);
       // And the failed init published nothing, so no half-built Sphere is reachable.
       expect(Sphere.getInstance()).toBeNull();
+      // Precisely because nothing is reachable, the failure path must tear the whole
+      // Sphere down — providers are connected and the vertical is running by now, and
+      // disposing only the registry would strand all of it with no owner.
+      expect(transport.disconnect).toHaveBeenCalled();
+      expect(storage.isConnected()).toBe(false);
     } finally {
       create.mockRestore();
       fs.rmSync(dataDir, { recursive: true, force: true });

--- a/tests/integration/sphere-payments-v2-wiring.test.ts
+++ b/tests/integration/sphere-payments-v2-wiring.test.ts
@@ -253,6 +253,63 @@ describe('Sphere payments wiring — the token registry is OWNED, not the proces
       fs.rmSync(dataDir, { recursive: true, force: true });
     }
   });
+
+  it('an init that REJECTS leaves no registry behind', async () => {
+    // The registry is built late, after the fallible validation. Built early, a rejected
+    // mnemonic would strand an unreachable registry fetching hourly with no owner to
+    // destroy it — the caller never receives a Sphere.
+    const create = vi.spyOn(TokenRegistry, 'create');
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-fail-'));
+    const storage = new FileStorageProvider({ dataDir });
+    try {
+      await expect(
+        Sphere.import({
+          storage,
+          transport: createMockTransport(),
+          oracle: createEngineOracle(),
+          mnemonic: 'clearly not a valid bip39 mnemonic phrase at all',
+          network: NET,
+          walletApi: makeWorld().walletApi,
+        })
+      ).rejects.toMatchObject({ code: 'INVALID_IDENTITY' });
+
+      // Either never built, or built and disposed — never left running.
+      for (const r of create.mock.results) {
+        expect((r.value as TokenRegistry).isDisposed).toBe(true);
+      }
+    } finally {
+      create.mockRestore();
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('destroy() disposes the registry even when teardown throws', async () => {
+    const create = vi.spyOn(TokenRegistry, 'create');
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pv2-registry-throw-'));
+    const storage = new FileStorageProvider({ dataDir });
+    const transport = createMockTransport();
+    try {
+      const { sphere } = await Sphere.init({
+        storage,
+        transport,
+        oracle: createEngineOracle(),
+        mnemonic: MNEMONIC,
+        network: NET,
+        walletApi: makeWorld().walletApi,
+      });
+      const owned = create.mock.results[0]!.value as TokenRegistry;
+
+      // Teardown below the disposal point propagates (the transport mux disconnect has
+      // no catch), so disposal must not sit behind it.
+      vi.spyOn(transport, 'disconnect').mockRejectedValue(new Error('teardown exploded'));
+
+      await sphere.destroy().catch(() => undefined);
+      expect(owned.isDisposed).toBe(true);
+    } finally {
+      create.mockRestore();
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('Sphere payments wiring — defaults (P11 flip: the vertical is default and only)', () => {

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -520,5 +520,35 @@
     "tests": [
       "tests/integration/sphere-payments-v2-wiring.test.ts"
     ]
+  },
+  {
+    "name": "registry-arms-interval-after-dispose",
+    "note": "#766 review: performInitialLoad's entry guard has already passed by the time the fetch resolves \u2014 without the re-check the continuation arms an interval on a disposed registry. The callback no-ops, but the TIMER is the leak.",
+    "file": "registry/TokenRegistry.ts",
+    "find": "      if (this.disposed) return loaded;",
+    "replace": "      if (false) return loaded;",
+    "tests": [
+      "tests/unit/registry/TokenRegistry.instances.test.ts"
+    ]
+  },
+  {
+    "name": "start-autorefresh-ignores-dispose",
+    "note": "#766 review: startAutoRefresh is public and must arm nothing on a disposed registry",
+    "file": "registry/TokenRegistry.ts",
+    "find": "    if (this.disposed) return;\n    this.stopAutoRefresh();",
+    "replace": "    this.stopAutoRefresh();",
+    "tests": [
+      "tests/unit/registry/TokenRegistry.instances.test.ts"
+    ]
+  },
+  {
+    "name": "init-failure-strands-registry",
+    "note": "#766 review: a rejected init must not leave an unreachable registry fetching hourly \u2014 the caller never receives a Sphere to destroy",
+    "file": "core/Sphere.ts",
+    "find": "      sphere._registry?.dispose();\n      sphere._registry = null;\n      throw err;",
+    "replace": "      throw err;",
+    "tests": [
+      "tests/integration/sphere-payments-v2-wiring.test.ts"
+    ]
   }
 ]

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -61,7 +61,7 @@
   },
   {
     "name": "requests-clear-link-on-failed-respond",
-    "note": "the settlement invariant: a settling link is removed ONLY by a CONFIRMED paid respond or a proven clean pre-commit failure — clearing it on a failed respond makes a paid request payable again after reload (requests.test.ts 'send-succeeds-respond-5xx')",
+    "note": "the settlement invariant: a settling link is removed ONLY by a CONFIRMED paid respond or a proven clean pre-commit failure \u2014 clearing it on a failed respond makes a paid request payable again after reload (requests.test.ts 'send-succeeds-respond-5xx')",
     "file": "modules/payments-v2/requests/Requests.ts",
     "find": "    if (!(opts.respond && (await this.respondPaid(requestId, transferId)))) {\n      this.setStatus(requestId, journalDown ? 'paid' : 'settling');\n      return;\n    }",
     "replace": "    const confirmed = opts.respond && (await this.respondPaid(requestId, transferId));\n    await this.clearLink(requestId).catch(() => undefined);\n    if (!confirmed) {\n      this.setStatus(requestId, journalDown ? 'paid' : 'settling');\n      return;\n    }",
@@ -101,7 +101,7 @@
   },
   {
     "name": "receive-ignores-epoch-bump",
-    "note": "§5.1/§5.7: the mailbox cursor must never survive a server restore — keeping it across an epoch bump silently loses every deposit whose post-restore seq is below the stale cursor (sphere-payments-v2-restore.test.ts missed-wake case + receive.test.ts self-detection)",
+    "note": "\u00a75.1/\u00a75.7: the mailbox cursor must never survive a server restore \u2014 keeping it across an epoch bump silently loses every deposit whose post-restore seq is below the stale cursor (sphere-payments-v2-restore.test.ts missed-wake case + receive.test.ts self-detection)",
     "file": "modules/payments-v2/receive/Receive.ts",
     "find": "        const served = deps.delivery.incomingEpoch();\n        if (basis === null || served === null || served === basis.syncEpoch) break;",
     "replace": "        const served = deps.delivery.incomingEpoch();\n        void served;\n        break;",
@@ -122,7 +122,7 @@
   },
   {
     "name": "receive-claim-conflict-swallow",
-    "note": "§5.7: a CONFLICT-bucket claim is terminally rejected('other') so the cursor advances — reverting to the swallow re-processes the entry every drain forever (receive.test.ts 'a CONFLICT-bucket claim is terminally rejected')",
+    "note": "\u00a75.7: a CONFLICT-bucket claim is terminally rejected('other') so the cursor advances \u2014 reverting to the swallow re-processes the entry every drain forever (receive.test.ts 'a CONFLICT-bucket claim is terminally rejected')",
     "file": "modules/payments-v2/receive/Receive.ts",
     "find": "    if (ack.disposition !== 'claimed' || !isClaimConflict(err)) throw err;",
     "replace": "    throw err;",
@@ -132,7 +132,7 @@
   },
   {
     "name": "receive-genesis-only-dedup",
-    "note": "dedup is (tokenId, stateHash), a re-acquired token at a new state is accepted (receive.test.ts 'A→B→A')",
+    "note": "dedup is (tokenId, stateHash), a re-acquired token at a new state is accepted (receive.test.ts 'A\u2192B\u2192A')",
     "file": "modules/payments-v2/receive/Receive.ts",
     "find": "  if (held === keys.stateHash) return { kind: 'ack', ack: claimAck(entry) };",
     "replace": "  if (held !== null) return { kind: 'ack', ack: claimAck(entry) };",
@@ -162,7 +162,7 @@
   },
   {
     "name": "providers-deliveryid-from-seq",
-    "note": "deliveryId is content-derived hex(SHA-256(tokenId ‖ stateHash)), never a server seq (providers.test.ts delivery-port contract)",
+    "note": "deliveryId is content-derived hex(SHA-256(tokenId \u2016 stateHash)), never a server seq (providers.test.ts delivery-port contract)",
     "file": "impl/wallet-api-v2/mailbox.ts",
     "find": "      deliveryId: entry.entryId,",
     "replace": "      deliveryId: String(entry.seq),",
@@ -192,7 +192,7 @@
   },
   {
     "name": "heartbeat-never-scheduled",
-    "note": "§7 in-session convergence: the heartbeat must actually schedule ticks — a keep-open send would otherwise sit half-done until app restart (heartbeat.test.ts in-session test)",
+    "note": "\u00a77 in-session convergence: the heartbeat must actually schedule ticks \u2014 a keep-open send would otherwise sit half-done until app restart (heartbeat.test.ts in-session test)",
     "file": "modules/payments-v2/convergence.ts",
     "find": "  private schedule(delayMs: number): void {\n    this.clearTimer();\n    if (!this.running) return;",
     "replace": "  private schedule(delayMs: number): void {\n    this.clearTimer();\n    if (delayMs >= 0) return;\n    if (!this.running) return;",
@@ -202,7 +202,7 @@
   },
   {
     "name": "facade-swallow-clean-failure-emit",
-    "note": "§4/#728: a CLEAN send failure emits transfer:updated{status:'failed'} before the rejection surfaces (facade.test.ts 'a CLEAN failure emits transfer:updated{status:failed}')",
+    "note": "\u00a74/#728: a CLEAN send failure emits transfer:updated{status:'failed'} before the rejection surfaces (facade.test.ts 'a CLEAN failure emits transfer:updated{status:failed}')",
     "file": "modules/payments-v2/PaymentsFacade.ts",
     "find": "    this.deps.emit('transfer:updated', failed);",
     "replace": "    void failed;",
@@ -212,7 +212,7 @@
   },
   {
     "name": "resume-reissues-fresh-transferid",
-    "note": "the retry path converges under the SAME transferId — a fresh id is a re-issued send and double-pays (#631/#676) (heartbeat.test.ts no-reissue asserts)",
+    "note": "the retry path converges under the SAME transferId \u2014 a fresh id is a re-issued send and double-pays (#631/#676) (heartbeat.test.ts no-reissue asserts)",
     "file": "modules/payments-v2/machine/resume.ts",
     "find": "    await ctx.machine.resumeIntent({\n      transferId: job.transferId,",
     "replace": "    await ctx.machine.resumeIntent({\n      transferId: `${job.transferId}:reissued`,",
@@ -222,7 +222,7 @@
   },
   {
     "name": "wiring-stamps-session-network-on-peer",
-    "note": "#733: the peer branch reports only what the binding PROVES — stamping the session network makes the §5.6 guard compare it with itself, i.e. unfalsifiable (facade.test.ts network-guard asserts)",
+    "note": "#733: the peer branch reports only what the binding PROVES \u2014 stamping the session network makes the \u00a75.6 guard compare it with itself, i.e. unfalsifiable (facade.test.ts network-guard asserts)",
     "file": "core/payments-v2-wiring.ts",
     "find": "    network: peer.network || null,",
     "replace": "    network,",
@@ -232,7 +232,7 @@
   },
   {
     "name": "transport-drops-network-from-raw-event",
-    "note": "#735 review: the transport-pubkey route is the ONE recipient route that can prove a network today — it must read the raw signed event, not lose it (recipient-network.transport.test.ts refuses a relay-declared foreign network end to end)",
+    "note": "#735 review: the transport-pubkey route is the ONE recipient route that can prove a network today \u2014 it must read the raw signed event, not lose it (recipient-network.transport.test.ts refuses a relay-declared foreign network end to end)",
     "file": "transport/NostrTransportProvider.ts",
     "find": "      const network = declaredNetwork(bindingEvent);",
     "replace": "      const network = undefined as string | undefined;",
@@ -242,7 +242,7 @@
   },
   {
     "name": "transport-invents-network-on-parsed-binding",
-    "note": "#735 review: the SDK-parsed @nametag/DIRECT:// routes cannot prove a network (parseBindingInfo whitelists it away) and must NOT invent one — a stamp silences the recipient:network-unverified signal, which is the #733 bug wearing a new hat (recipient-network.transport.test.ts LIMITATION asserts)",
+    "note": "#735 review: the SDK-parsed @nametag/DIRECT:// routes cannot prove a network (parseBindingInfo whitelists it away) and must NOT invent one \u2014 a stamp silences the recipient:network-unverified signal, which is the #733 bug wearing a new hat (recipient-network.transport.test.ts LIMITATION asserts)",
     "file": "transport/NostrTransportProvider.ts",
     "find": "    return {\n      nametag: nametag || binding.nametag,",
     "replace": "    return {\n      network: 'testnet2',\n      nametag: nametag || binding.nametag,",
@@ -252,7 +252,7 @@
   },
   {
     "name": "inventory-pinned-counts-as-confirmed",
-    "note": "#737: a token pinned by an open intent is reported transferring, never confirmed/spendable — the reporter reads the reservation, not just this session's in-flight set",
+    "note": "#737: a token pinned by an open intent is reported transferring, never confirmed/spendable \u2014 the reporter reads the reservation, not just this session's in-flight set",
     "file": "modules/payments-v2/compose.ts",
     "find": "    isPinned: (tokenId) => ledger.unprovenReason() !== null || ledger.holderOf(tokenId) !== undefined,",
     "replace": "    isPinned: () => false,",
@@ -262,7 +262,7 @@
   },
   {
     "name": "queue-refusal-hides-the-pin",
-    "note": "#737: SEND_INSUFFICIENT_BALANCE must name the pinned amount and the transfers holding it — 'insufficient balance' alone sent a user auditing a treasury that was never short",
+    "note": "#737: SEND_INSUFFICIENT_BALANCE must name the pinned amount and the transfers holding it \u2014 'insufficient balance' alone sent a user auditing a treasury that was never short",
     "file": "modules/payments-v2/select/queue.ts",
     "find": "    view.pinnedTotal > 0n",
     "replace": "    (false as boolean)",
@@ -302,7 +302,7 @@
   },
   {
     "name": "report-ignores-unproven-heldset",
-    "note": "#738: while the held-set is unproven the REPORT must agree with the refusal — otherwise a treasury reads fully spendable while every send is refused (#737's complaint).",
+    "note": "#738: while the held-set is unproven the REPORT must agree with the refusal \u2014 otherwise a treasury reads fully spendable while every send is refused (#737's complaint).",
     "file": "modules/payments-v2/compose.ts",
     "find": "    isPinned: (tokenId) => ledger.unprovenReason() !== null || ledger.holderOf(tokenId) !== undefined,",
     "replace": "    isPinned: (tokenId) => ledger.holderOf(tokenId) !== undefined,",
@@ -373,7 +373,7 @@
   },
   {
     "name": "proof-wait-retries-everything",
-    "note": "#741: tolerance must be scoped to transient statuses — retrying a genuine 4xx hides a real error until the deadline.",
+    "note": "#741: tolerance must be scoped to transient statuses \u2014 retrying a genuine 4xx hides a real error until the deadline.",
     "file": "token-engine/proof-wait.ts",
     "find": "  return err instanceof JsonRpcNetworkError && TRANSIENT_HTTP_STATUSES.has(err.status);",
     "replace": "  return err instanceof JsonRpcNetworkError;",
@@ -383,9 +383,9 @@
   },
   {
     "name": "submit-429-not-retried",
-    "note": "#746: the metered call is the SUBMIT. Without retry a 429 falls through to a proof wait for a request the gateway never accepted, burning the whole deadline per op — which is what made raising CERTIFY_WIDTH unsafe.",
+    "note": "#746: the metered call is the SUBMIT. Without retry a 429 falls through to a proof wait for a request the gateway never accepted, burning the whole deadline per op \u2014 which is what made raising CERTIFY_WIDTH unsafe.",
     "file": "token-engine/SphereTokenEngine.ts",
-    "find": "      const { value: response, retried } = await retryTransient(\n        async () => {\n          const answer = await this.deps.client.submitCertificationRequest(certificationData);\n          // A booting gateway is \"ask again\", not a certification failure — see\n          // TransientSubmitAnswer. Everything else, known or unknown, keeps the\n          // status-agnostic treatment below.\n          if (String(answer.status) === String(CertificationStatus.SERVICE_NOT_READY)) {\n            throw new TransientSubmitAnswer(String(answer.status));\n          }\n          return answer;\n        },\n        signal,\n        this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS,\n      );",
+    "find": "      const { value: response, retried } = await retryTransient(\n        async () => {\n          const answer = await this.deps.client.submitCertificationRequest(certificationData);\n          // A booting gateway is \"ask again\", not a certification failure \u2014 see\n          // TransientSubmitAnswer. Everything else, known or unknown, keeps the\n          // status-agnostic treatment below.\n          if (String(answer.status) === String(CertificationStatus.SERVICE_NOT_READY)) {\n            throw new TransientSubmitAnswer(String(answer.status));\n          }\n          return answer;\n        },\n        signal,\n        this.deps.proofPollIntervalMs ?? DEFAULT_PROOF_POLL_INTERVAL_MS,\n      );",
     "replace": "      const response = await this.deps.client.submitCertificationRequest(certificationData);\n      const retried = false;",
     "tests": [
       "tests/unit/token-engine/proof-deadline.test.ts"
@@ -403,7 +403,7 @@
   },
   {
     "name": "resume-conflict-masks-ordinary-failure",
-    "note": "#745 review: summarize ranks conflict above 'other', so gating on the aggregate class let a conflict license settlement while an ordinarily-failed leg was in neither committed[] nor conflicts[] — understated shortfall on a closed intent.",
+    "note": "#745 review: summarize ranks conflict above 'other', so gating on the aggregate class let a conflict license settlement while an ordinarily-failed leg was in neither committed[] nor conflicts[] \u2014 understated shortfall on a closed intent.",
     "file": "modules/payments-v2/machine/TransferMachine.ts",
     "find": "    const blocking = firstNonConflictError(outcomes);\n    if (blocking !== undefined) throw blocking.error;",
     "replace": "    const { cls, firstError } = summarize(outcomes);\n    if (cls !== null && cls !== 'conflict') throw firstError;",
@@ -423,7 +423,7 @@
   },
   {
     "name": "retry-attempts-after-abort",
-    "note": "#747 review: pause() resolves on abort too, so without a pre-attempt signal check the loop issues one more request past the deadline — and a hanging one un-bounds the operation.",
+    "note": "#747 review: pause() resolves on abort too, so without a pre-attempt signal check the loop issues one more request past the deadline \u2014 and a hanging one un-bounds the operation.",
     "file": "token-engine/proof-wait.ts",
     "find": "    if (signal.aborted) throw signal.reason as Error;\n    try {",
     "replace": "    try {",
@@ -433,7 +433,7 @@
   },
   {
     "name": "send-reports-no-progress",
-    "note": "A multi-token send must report each leg as it certifies; without it the UI can only show a spinner (per-leg, not per-wave — a <=CERTIFY_WIDTH send is one wave).",
+    "note": "A multi-token send must report each leg as it certifies; without it the UI can only show a spinner (per-leg, not per-wave \u2014 a <=CERTIFY_WIDTH send is one wave).",
     "file": "modules/payments-v2/machine/TransferMachine.ts",
     "find": "            if (o.certified) {\n              certified.push(o);\n              this.emitProgress(plan, certified);\n            }",
     "replace": "            if (o.certified) {\n              certified.push(o);\n            }",
@@ -445,7 +445,7 @@
     "name": "compose-drops-sender-nametag",
     "note": "sphere#487: buildMachineDeps forwards the live ownNametag getter, so every deliver puts the sender's Unicity ID on the wire (facade.test.ts '#487 the delivered envelope carries the sender @nametag'). Dropping it IS the regression the payments-v2 rewrite shipped: the recipient renders 'Someone'.",
     "file": "modules/payments-v2/compose.ts",
-    "find": "    // sphere#487: the same live getter Requests uses — the delivery envelope is\n    // the recipient's ONLY source for the sender's Unicity ID.\n    ...(deps.ownNametag !== undefined ? { ownNametag: deps.ownNametag } : {}),\n",
+    "find": "    // sphere#487: the same live getter Requests uses \u2014 the delivery envelope is\n    // the recipient's ONLY source for the sender's Unicity ID.\n    ...(deps.ownNametag !== undefined ? { ownNametag: deps.ownNametag } : {}),\n",
     "replace": "    // mutant: the machine no longer learns the wallet's own Unicity ID\n",
     "tests": [
       "tests/unit/payments-v2/facade.test.ts"
@@ -453,7 +453,7 @@
   },
   {
     "name": "replay-drops-sender-nametag",
-    "note": "sphere#487: a leg delivered from the journal (after a crash or a 429 defer) carries the sender nametag too — machine.test.ts '#487 every deliver carries the sender nametag'. Without it a deferred transfer arrives anonymous while a direct one does not.",
+    "note": "sphere#487: a leg delivered from the journal (after a crash or a 429 defer) carries the sender nametag too \u2014 machine.test.ts '#487 every deliver carries the sender nametag'. Without it a deferred transfer arrives anonymous while a direct one does not.",
     "file": "modules/payments-v2/machine/journal.ts",
     "find": "        ...senderNametagOption(deps.ownNametag),\n",
     "replace": "        // mutant: a replayed leg arrives anonymous\n",
@@ -463,7 +463,7 @@
   },
   {
     "name": "sphere-host-nametag-dropped",
-    "note": "sphere#487: the last link — Sphere hands the vertical the wallet's own Unicity ID (address-scoped, since switchToAddress moves _currentAddressIndex before stopping this facade). Every unit suite injects its own getter, so only the composed integration test sees this one.",
+    "note": "sphere#487: the last link \u2014 Sphere hands the vertical the wallet's own Unicity ID (address-scoped, since switchToAddress moves _currentAddressIndex before stopping this facade). Every unit suite injects its own getter, so only the composed integration test sees this one.",
     "file": "core/Sphere.ts",
     "find": "        nametag: () => this.getNametagForAddress(facadeAddressId),",
     "replace": "        nametag: () => undefined, // mutant: the vertical never learns its own name",
@@ -483,12 +483,42 @@
   },
   {
     "name": "kv-generation-not-renamed",
-    "note": "The scoped-KV prefix rename IS the 3.x local migration. Left on `pv2:`, the sync-epoch latch survives a backend reset, so noteEpoch sees a CHANGED epoch, runs the restore protocol, and re-PUTs every locally-open intent into the freshly wiped backend — permanent pendingTransfers() rows holding their sources reserved, with no error surface.",
+    "note": "The scoped-KV prefix rename IS the 3.x local migration. Left on `pv2:`, the sync-epoch latch survives a backend reset, so noteEpoch sees a CHANGED epoch, runs the restore protocol, and re-PUTs every locally-open intent into the freshly wiped backend \u2014 permanent pendingTransfers() rows holding their sources reserved, with no error surface.",
     "file": "modules/payments-v2/stores.ts",
     "find": "  const prefix = `${KV_PREFIX}${network}:${chainPubkey}:`;",
     "replace": "  const prefix = `pv2:${network}:${chainPubkey}:`;",
     "tests": [
       "tests/unit/payments-v2/kv-generation.test.ts"
+    ]
+  },
+  {
+    "name": "registry-create-returns-global",
+    "note": "#766: TokenRegistry.create() must build an INDEPENDENT instance \u2014 returning the singleton reinstates the cross-Sphere metadata clobber (a mainnet init flipping a live testnet2 wallet's decimals to 0)",
+    "file": "registry/TokenRegistry.ts",
+    "find": "    const registry = new TokenRegistry();",
+    "replace": "    const registry = TokenRegistry.getInstance();",
+    "tests": [
+      "tests/unit/registry/TokenRegistry.instances.test.ts"
+    ]
+  },
+  {
+    "name": "registry-dispose-noop",
+    "note": "#766: dispose() must actually stop the registry \u2014 nothing in registry/ calls unref(), so a surviving interval outlives the Sphere that created it and keeps Node's event loop alive",
+    "file": "registry/TokenRegistry.ts",
+    "find": "    this.disposed = true;\n    this.stopAutoRefresh();",
+    "replace": "    this.disposed = true;",
+    "tests": [
+      "tests/unit/registry/TokenRegistry.instances.test.ts"
+    ]
+  },
+  {
+    "name": "sphere-destroy-leaks-registry",
+    "note": "#766: Sphere.destroy() must dispose the registry it owns; without it every discarded wallet leaves an hourly fetch running",
+    "file": "core/Sphere.ts",
+    "find": "    this._registry?.dispose();",
+    "replace": "    void this._registry;",
+    "tests": [
+      "tests/integration/sphere-payments-v2-wiring.test.ts"
     ]
   }
 ]

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -552,11 +552,11 @@
     ]
   },
   {
-    "name": "registry-cleanup-misses-module-bringup",
-    "note": "#767 review: the dispose-on-failure guard must cover module bring-up too \u2014 an oracle with no trust base makes startPaymentsV2Inner throw INVALID_CONFIG after providers are up, stranding the registry",
+    "name": "registry-cleanup-not-total",
+    "note": "#767 review: the dispose-on-failure guard must cover EVERY step from registry creation until Sphere.instance is published \u2014 twice it covered a named subset and the next step along was unguarded",
     "file": "core/Sphere.ts",
-    "find": "      await sphere.initializeProviders();\n      await sphere.initializeModules();",
-    "replace": "      await sphere.initializeProviders();\n      const _m = sphere.initializeModules(); await _m.catch(() => undefined);",
+    "find": "    } catch (err) {\n      sphere._registry?.dispose();\n      sphere._registry = null;\n      throw err;\n    }",
+    "replace": "    } catch (err) {\n      throw err;\n    }",
     "tests": [
       "tests/integration/sphere-payments-v2-wiring.test.ts"
     ]

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -580,5 +580,25 @@
     "tests": [
       "tests/unit/registry/TokenRegistry.instances.test.ts"
     ]
+  },
+  {
+    "name": "dispose-ignores-inflight-fetch",
+    "note": "#767 review: dispose() must ABORT the request already in the air \u2014 the fetch and its abort timer each hold Node's event loop open for FETCH_TIMEOUT_MS after teardown",
+    "file": "registry/TokenRegistry.ts",
+    "find": "    this.inFlight?.abort();",
+    "replace": "    void this.inFlight;",
+    "tests": [
+      "tests/unit/registry/TokenRegistry.instances.test.ts"
+    ]
+  },
+  {
+    "name": "teardown-stops-at-first-failure",
+    "note": "#767 review: destroy()'s disconnects are independent resources \u2014 one rejecting must not skip the rest, or a partial teardown failure leaves connections open",
+    "file": "core/Sphere.ts",
+    "find": "      await Sphere.safeDisconnect(what, disconnect);",
+    "replace": "      await disconnect();",
+    "tests": [
+      "tests/integration/sphere-payments-v2-wiring.test.ts"
+    ]
   }
 ]

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -543,20 +543,20 @@
   },
   {
     "name": "init-failure-strands-registry",
-    "note": "#766 review: a rejected init must not leave an unreachable registry fetching hourly \u2014 the caller never receives a Sphere to destroy",
+    "note": "#767: a rejection inside the guarded bring-up must actually reach the catch \u2014 swallowing it would leave a half-built Sphere published and reported as success",
     "file": "core/Sphere.ts",
-    "find": "      sphere._registry?.dispose();\n      sphere._registry = null;\n      throw err;",
-    "replace": "      throw err;",
+    "find": "    try {\n      await bringUp();\n    } catch (err) {",
+    "replace": "    try {\n      await bringUp().catch(() => undefined);\n    } catch (err) {",
     "tests": [
       "tests/integration/sphere-payments-v2-wiring.test.ts"
     ]
   },
   {
-    "name": "registry-cleanup-not-total",
-    "note": "#767 review: the dispose-on-failure guard must cover EVERY step from registry creation until Sphere.instance is published \u2014 twice it covered a named subset and the next step along was unguarded",
+    "name": "init-failure-swallows-error",
+    "note": "#767: the guard must RETHROW after teardown \u2014 swallowing turns a failed init into a resolved one returning a destroyed Sphere",
     "file": "core/Sphere.ts",
-    "find": "    } catch (err) {\n      sphere._registry?.dispose();\n      sphere._registry = null;\n      throw err;\n    }",
-    "replace": "    } catch (err) {\n      throw err;\n    }",
+    "find": "      });\n      throw err;\n    }\n  }",
+    "replace": "      });\n    }\n  }",
     "tests": [
       "tests/integration/sphere-payments-v2-wiring.test.ts"
     ]
@@ -569,6 +569,16 @@
     "replace": "      await Promise.resolve().catch((teardownErr) => {",
     "tests": [
       "tests/integration/sphere-payments-v2-wiring.test.ts"
+    ]
+  },
+  {
+    "name": "waitforready-leaks-timeout",
+    "note": "#767 local-codex review: Promise.race does not cancel the loser \u2014 an uncleared readiness timeout holds Node's event loop open for its full duration, up to 10s after dispose",
+    "file": "registry/TokenRegistry.ts",
+    "find": "      if (timer !== undefined) clearTimeout(timer);",
+    "replace": "      void timer;",
+    "tests": [
+      "tests/unit/registry/TokenRegistry.instances.test.ts"
     ]
   }
 ]

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -560,5 +560,15 @@
     "tests": [
       "tests/integration/sphere-payments-v2-wiring.test.ts"
     ]
+  },
+  {
+    "name": "init-failure-leaks-whole-sphere",
+    "note": "#767 review: a failed init must tear down the WHOLE Sphere \u2014 publication happens after the guard, so providers/vertical/engine would otherwise be unreachable with no owner",
+    "file": "core/Sphere.ts",
+    "find": "      await sphere.destroy().catch((teardownErr) => {",
+    "replace": "      await Promise.resolve().catch((teardownErr) => {",
+    "tests": [
+      "tests/integration/sphere-payments-v2-wiring.test.ts"
+    ]
   }
 ]

--- a/tests/mutation/probes.json
+++ b/tests/mutation/probes.json
@@ -550,5 +550,15 @@
     "tests": [
       "tests/integration/sphere-payments-v2-wiring.test.ts"
     ]
+  },
+  {
+    "name": "registry-cleanup-misses-module-bringup",
+    "note": "#767 review: the dispose-on-failure guard must cover module bring-up too \u2014 an oracle with no trust base makes startPaymentsV2Inner throw INVALID_CONFIG after providers are up, stranding the registry",
+    "file": "core/Sphere.ts",
+    "find": "      await sphere.initializeProviders();\n      await sphere.initializeModules();",
+    "replace": "      await sphere.initializeProviders();\n      const _m = sphere.initializeModules(); await _m.catch(() => undefined);",
+    "tests": [
+      "tests/integration/sphere-payments-v2-wiring.test.ts"
+    ]
   }
 ]

--- a/tests/unit/registry/TokenRegistry.instances.test.ts
+++ b/tests/unit/registry/TokenRegistry.instances.test.ts
@@ -56,6 +56,11 @@ function stubFetch(): { calls: string[]; restore: () => void } {
   return { calls, restore: () => { globalThis.fetch = original; } };
 }
 
+/** The private timer handle IS the leak, so assert on it directly. */
+function hasLiveInterval(r: TokenRegistry): boolean {
+  return (r as unknown as { refreshTimer: unknown }).refreshTimer !== null;
+}
+
 afterEach(() => {
   TokenRegistry.destroy();
   vi.useRealTimers();
@@ -194,6 +199,44 @@ describe('TokenRegistry#dispose', () => {
 
       expect(await owned.refreshFromRemote()).toBe(false);
       expect(f.calls.length).toBe(after);
+    } finally {
+      f.restore();
+    }
+  });
+  it('dispose DURING the initial load leaves no interval armed', async () => {
+    // The entry guard in performInitialLoad has already passed by the time the fetch
+    // resolves, and the continuation arms the interval. The callback would no-op via the
+    // disposed flag, but the TIMER is the leak.
+    const { storage } = makeStorage();
+    let release!: (r: Response) => void;
+    let requested = false;
+    const pending = new Promise<Response>((resolve) => { release = resolve; });
+    const original = globalThis.fetch;
+    globalThis.fetch = (() => { requested = true; return pending; }) as typeof globalThis.fetch;
+    try {
+      const owned = TokenRegistry.create({ remoteUrl: URL_A, storage, autoRefresh: true });
+      for (let i = 0; i < 200 && !requested; i++) await new Promise((r) => setTimeout(r, 1));
+      expect(requested).toBe(true);
+
+      owned.dispose();
+      release(new Response(JSON.stringify(defsA), { status: 200 }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      // If the continuation armed an interval, the process now holds a live timer.
+      expect(hasLiveInterval(owned)).toBe(false);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('startAutoRefresh after dispose arms nothing', async () => {
+    const { storage } = makeStorage();
+    const f = stubFetch();
+    try {
+      const owned = TokenRegistry.create({ remoteUrl: URL_A, storage, autoRefresh: false });
+      owned.dispose();
+      owned.startAutoRefresh(1000);
+      expect(hasLiveInterval(owned)).toBe(false);
     } finally {
       f.restore();
     }

--- a/tests/unit/registry/TokenRegistry.instances.test.ts
+++ b/tests/unit/registry/TokenRegistry.instances.test.ts
@@ -241,4 +241,20 @@ describe('TokenRegistry#dispose', () => {
       f.restore();
     }
   });
+  it('waitForReady leaves no timer behind when the load wins the race', async () => {
+    // Promise.race does not cancel the loser. An unreferenced setTimeout still holds
+    // Node's event loop open for its full duration — with the 10s default, well past
+    // the point the registry has been disposed.
+    vi.useFakeTimers();
+    const { storage } = makeStorage();
+    const f = stubFetch();
+    try {
+      const owned = TokenRegistry.create({ remoteUrl: URL_A, storage, autoRefresh: false });
+      const before = vi.getTimerCount();
+      await owned.waitForReady(10_000);
+      expect(vi.getTimerCount()).toBe(before);
+    } finally {
+      f.restore();
+    }
+  });
 });

--- a/tests/unit/registry/TokenRegistry.instances.test.ts
+++ b/tests/unit/registry/TokenRegistry.instances.test.ts
@@ -257,4 +257,32 @@ describe('TokenRegistry#dispose', () => {
       f.restore();
     }
   });
+  it('dispose ABORTS an in-flight fetch rather than merely ignoring its result', async () => {
+    // Discarding the promise reference is not enough: the request and its 10s abort timer
+    // both keep Node's event loop alive until the timeout elapses, long after teardown.
+    const { storage } = makeStorage();
+    let aborted = false;
+    let requested = false;
+    const original = globalThis.fetch;
+    globalThis.fetch = ((_input: unknown, init?: { signal?: AbortSignal }) => {
+      requested = true;
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          aborted = true;
+          reject(new Error('aborted'));
+        });
+      });
+    }) as typeof globalThis.fetch;
+    try {
+      const owned = TokenRegistry.create({ remoteUrl: URL_A, storage, autoRefresh: true });
+      for (let i = 0; i < 200 && !requested; i++) await new Promise((r) => setTimeout(r, 1));
+      expect(requested).toBe(true); // vacuous if the fetch never started
+
+      owned.dispose();
+      await new Promise((r) => setTimeout(r, 20));
+      expect(aborted).toBe(true);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
 });

--- a/tests/unit/registry/TokenRegistry.instances.test.ts
+++ b/tests/unit/registry/TokenRegistry.instances.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Owned registries: TokenRegistry.create() + dispose().
+ *
+ * The defect these pin, observed empirically: with a testnet2 Sphere live and holding a
+ * coin, initialising a second Sphere on mainnet flipped the FIRST instance's own asset
+ * from {symbol:'TCOIN', decimals:8} to {symbol:'AAAAAA', decimals:0} — a silent 10^8
+ * scale error on a live balance. The mechanism was the process-global: configure()
+ * reaches into whatever instance exists and repoints it, so every Sphere shared one.
+ *
+ * An owned registry must be immune to that, and must stop completely when disposed —
+ * nothing here calls unref(), so a surviving interval keeps Node's event loop alive.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TokenRegistry } from '../../../registry';
+import type { TokenDefinition } from '../../../registry';
+import type { StorageProvider } from '../../../storage';
+
+const URL_A = 'https://example.com/net-a.json';
+const URL_B = 'https://example.com/net-b.json';
+
+const COIN_A = 'aa'.repeat(32);
+const COIN_B = 'bb'.repeat(32);
+
+const defsA: TokenDefinition[] = [
+  { network: 'unicity:net-a', assetKind: 'fungible', name: 'acoin', symbol: 'ACOIN', decimals: 8, description: 'A', id: COIN_A },
+];
+const defsB: TokenDefinition[] = [
+  { network: 'unicity:net-b', assetKind: 'fungible', name: 'bcoin', symbol: 'BCOIN', decimals: 6, description: 'B', id: COIN_B },
+];
+
+function makeStorage(): { storage: StorageProvider; store: Map<string, string> } {
+  const store = new Map<string, string>();
+  const storage = {
+    get: async (k: string) => store.get(k) ?? null,
+    set: async (k: string, v: string) => { store.set(k, v); },
+    remove: async (k: string) => { store.delete(k); },
+    has: async (k: string) => store.has(k),
+    clear: async () => { store.clear(); },
+    setIdentity: () => {},
+  } as unknown as StorageProvider;
+  return { storage, store };
+}
+
+/** Serve each URL its own definitions, and count requests per URL. */
+function stubFetch(): { calls: string[]; restore: () => void } {
+  const calls: string[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: unknown) => {
+    const url = String(input);
+    calls.push(url);
+    const body = url === URL_A ? defsA : url === URL_B ? defsB : [];
+    return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+  }) as typeof globalThis.fetch;
+  return { calls, restore: () => { globalThis.fetch = original; } };
+}
+
+afterEach(() => {
+  TokenRegistry.destroy();
+  vi.useRealTimers();
+});
+
+describe('TokenRegistry.create — an owned registry is independent of the global', () => {
+  it('resolves its own network while the global resolves another', async () => {
+    const { storage } = makeStorage();
+    const f = stubFetch();
+    try {
+      TokenRegistry.configure({ remoteUrl: URL_A, storage, autoRefresh: true });
+      await TokenRegistry.waitForReady();
+
+      const owned = TokenRegistry.create({ remoteUrl: URL_B, storage, autoRefresh: true });
+      await owned.waitForReady();
+
+      // Each answers for its OWN network, at the same moment.
+      expect(owned.getSymbol(COIN_B)).toBe('BCOIN');
+      expect(owned.getDecimals(COIN_B)).toBe(6);
+      expect(TokenRegistry.getInstance().getSymbol(COIN_A)).toBe('ACOIN');
+      expect(TokenRegistry.getInstance().getDecimals(COIN_A)).toBe(8);
+
+      // ...and neither can see the other's coin.
+      expect(owned.isKnown(COIN_A)).toBe(false);
+      expect(TokenRegistry.getInstance().isKnown(COIN_B)).toBe(false);
+    } finally {
+      f.restore();
+    }
+  });
+
+  it('survives the global being repointed — the exact reported defect', async () => {
+    const { storage } = makeStorage();
+    const f = stubFetch();
+    try {
+      const owned = TokenRegistry.create({ remoteUrl: URL_A, storage, autoRefresh: true });
+      await owned.waitForReady();
+      expect(owned.getDecimals(COIN_A)).toBe(8);
+
+      // A second Sphere initialises on another network: it configures the global.
+      TokenRegistry.configure({ remoteUrl: URL_B, storage, autoRefresh: true });
+      await TokenRegistry.waitForReady();
+
+      // The first wallet's metadata is untouched. Before this change it became
+      // {symbol:'AAAAAA', decimals:0} — the miss fallbacks.
+      expect(owned.getSymbol(COIN_A)).toBe('ACOIN');
+      expect(owned.getDecimals(COIN_A)).toBe(8);
+      expect(owned.isKnown(COIN_A)).toBe(true);
+    } finally {
+      f.restore();
+    }
+  });
+
+  it('two owned registries on different networks do not disturb each other', async () => {
+    const { storage } = makeStorage();
+    const f = stubFetch();
+    try {
+      const a = TokenRegistry.create({ remoteUrl: URL_A, storage, autoRefresh: true });
+      const b = TokenRegistry.create({ remoteUrl: URL_B, storage, autoRefresh: true });
+      await Promise.all([a.waitForReady(), b.waitForReady()]);
+
+      expect(a.getDecimals(COIN_A)).toBe(8);
+      expect(b.getDecimals(COIN_B)).toBe(6);
+      expect(a.isKnown(COIN_B)).toBe(false);
+      expect(b.isKnown(COIN_A)).toBe(false);
+    } finally {
+      f.restore();
+    }
+  });
+});
+
+describe('TokenRegistry#dispose', () => {
+  it('stops the refresh timer, so a discarded owner leaves no work behind', async () => {
+    vi.useFakeTimers();
+    const { storage } = makeStorage();
+    const f = stubFetch();
+    try {
+      const owned = TokenRegistry.create({
+        remoteUrl: URL_A,
+        storage,
+        autoRefresh: true,
+        refreshIntervalMs: 1000,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      const before = f.calls.length;
+      expect(before).toBeGreaterThan(0);
+
+      owned.dispose();
+      expect(owned.isDisposed).toBe(true);
+
+      // Well past several intervals: a live timer would have fetched again.
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(f.calls.length).toBe(before);
+    } finally {
+      f.restore();
+    }
+  });
+
+  it('a response landing AFTER dispose is neither applied nor cached', async () => {
+    const { storage, store } = makeStorage();
+    let release!: (r: Response) => void;
+    let requested = false;
+    const pending = new Promise<Response>((resolve) => { release = resolve; });
+    const original = globalThis.fetch;
+    globalThis.fetch = (() => { requested = true; return pending; }) as typeof globalThis.fetch;
+    try {
+      const owned = TokenRegistry.create({ remoteUrl: URL_A, storage, autoRefresh: true });
+      for (let i = 0; i < 200 && !requested; i++) await new Promise((r) => setTimeout(r, 1));
+      expect(requested).toBe(true); // the test is vacuous if the fetch never started
+
+      owned.dispose();
+      release(new Response(JSON.stringify(defsA), { status: 200 }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(owned.isKnown(COIN_A)).toBe(false);
+      for (const [, v] of store) expect(v).not.toContain(COIN_A);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('starts no new work after dispose', async () => {
+    const { storage } = makeStorage();
+    const f = stubFetch();
+    try {
+      const owned = TokenRegistry.create({ remoteUrl: URL_A, storage, autoRefresh: true });
+      await owned.waitForReady();
+      owned.dispose();
+      const after = f.calls.length;
+
+      expect(await owned.refreshFromRemote()).toBe(false);
+      expect(f.calls.length).toBe(after);
+    } finally {
+      f.restore();
+    }
+  });
+});

--- a/tests/unit/registry/TokenRegistry.instances.test.ts
+++ b/tests/unit/registry/TokenRegistry.instances.test.ts
@@ -141,11 +141,18 @@ describe('TokenRegistry#dispose', () => {
       await vi.advanceTimersByTimeAsync(0);
       const before = f.calls.length;
       expect(before).toBeGreaterThan(0);
+      const timersBefore = vi.getTimerCount();
+      expect(timersBefore).toBeGreaterThan(0);
 
       owned.dispose();
       expect(owned.isDisposed).toBe(true);
 
-      // Well past several intervals: a live timer would have fetched again.
+      // The interval must be CLEARED, not merely made inert by the disposed flag: an
+      // un-cleared interval is the leak — it keeps Node's event loop alive on its own,
+      // whether or not its callback still fetches.
+      expect(vi.getTimerCount()).toBeLessThan(timersBefore);
+
+      // ...and well past several intervals, no further fetch either.
       await vi.advanceTimersByTimeAsync(5000);
       expect(f.calls.length).toBe(before);
     } finally {


### PR DESCRIPTION
Part of #766 (item 1 of 5). Scoped to the registry alone — the only piece that produced an actual wrong number. The other four are independent and shippable separately.

## The defect

`TokenRegistry` is a process-global singleton whose `configure()` repoints whatever instance exists, and every `Sphere.init()` calls it. So a second Sphere silently rewrites the first one's metadata.

Reproduced with two Spheres on **separate storage providers**:

```
instance #1 (testnet2), reading its own asset
  BEFORE the mainnet init:  { symbol: 'TCOIN', name: 'TestnetCoin', decimals: 8 }
  AFTER  the mainnet init:  { symbol: 'AAAAAA', name: 'aaaa…aa',    decimals: 0 }
```

`AAAAAA` is `coinId.slice(0,6).toUpperCase()`, `0` is `decimals ?? 0` — the miss fallbacks. Nothing on instance #1 restores it: not `switchToAddress`, not `setOracleApiKey`.

**One correction to how I described this earlier.** It is presentation-only *inside* the SDK — the money path treats `coinId` as opaque bytes, `mint()` rejects non-hex, selection byte-compares. It is **not** presentation-only at the consumer boundary: `sphere`'s `useTopUp.ts:58-88` takes both the coinId *and* the decimals it hands to `payments.mint()` from the global, `useAssets.ts:69-80` overwrites the facade's decimals with a global read, and `agentic-chatbot`'s `chess-bot/wallet.ts:61-62,81` derives its send coinId and decimals the same way. There a retargeted registry is a wrong-coin mint and a 10ⁿ scale error.

Separately: `Sphere.destroy()` never touched the registry, so every discarded Sphere left an hourly fetch running. Nothing in `registry/` calls `unref()`, so under Node it kept the event loop alive too — which is literally the requirement this issue is about.

## What changed

- **Sphere builds and owns a registry** (`TokenRegistry.create`) and the facade presents from it. `PaymentsV2Host` gains `registry`; `payments-v2-wiring` no longer reaches for `getInstance()`. The facade side is one line because the dep was already typed as the structural `RegistryReader`.
- **`Sphere.destroy()` disposes it.** Assigned post-construction beside `_verification`, not as a positional arg — the private constructor takes 7 args with four optional trailing ones, so a mis-ordered registry would land in `priceProvider` and still typecheck.
- **New API**: `TokenRegistry.create()`, instance `dispose()` / `isDisposed` / `waitForReady()`. Static `configure()` now delegates to the same private `applyConfig` the owned instances use, so there is one code path and the #765 generation guard is untouched.
- **`createBrowserProviders`/`createNodeProviders` no longer call `configure()`.** In the published package those bundles carry their own inlined copy no consumer can reach (`tsup` inlines `registry/` per entry with `splitting:false`), so the call was writing to an unreadable object while holding an unstoppable interval.
- **The ten free functions moved to `registry/global-readers.ts`**, re-exported unchanged. `TokenRegistry.ts` was over the 800-line budget, and this makes their eventual removal a file deletion.

## Consumer impact: none

Public surface is identical — **126 root exports before and after**, same names, same signatures. `PaymentsV2Host` is not public. All ten free functions still export from the same paths.

The one behavioural change: if you call a provider factory and read the global **without** `Sphere.init()`, configure it yourself. In the published package that path never worked anyway (separate bundle copies), so this is a no-op for package consumers. `docs/MIGRATION-TOKEN-REGISTRY.md` has the two lines, plus how to prepare for the global's eventual removal.

## Why the global is still there

Deliberate. Consumers read it directly, and disposing a shared object would be visible to them — `sphere/src/sdk/SphereProvider.tsx:535-538` shows the frontend already knows about the bundle plurality and configures its own copy. Deleting it is a coordinated ~28-file change across three repos and belongs in its own PR.

## Verification

- typecheck + typecheck:tests clean, lint 0 errors (suppressions baseline unchanged), build clean
- **2054 tests / 119 files**, **52/52 mutation probes KILLED** (three new ones over `registry/`, which had none)

Every guard was falsified before being trusted: `create()` returning the singleton reds the three isolation tests; a no-op `dispose()` reds the three teardown tests; Sphere passing the global reds the ownership test; dropping the `destroy()` dispose reds it differently.

**One of those probes survived first time round, and that is the useful part of this PR.** `registry-dispose-noop` removed `stopAutoRefresh()` from `dispose()` and everything stayed green — my test only asserted "no further fetch", which the `disposed` early-out satisfies on its own while the interval keeps running. The test could not have caught the absence of the thing it was guarding. It now asserts `vi.getTimerCount()` drops across `dispose()`. That is the third time on this line of work that a guard's test was incapable of catching the guard's removal; here the mutation runner caught it rather than a reviewer, which is the argument for landing probes in the same commit as the code.

## Not fixed here

`Sphere`'s own `static instance`, and `clear()`/`import()` destroying whichever instance holds it regardless of the storage they were given. Two `FileStorageProvider`s on one `dataDir` also clobber each other's wallet file. Those are the remainder of "create new ones at the same time" and stay in #766.

No version assigned — `[Unreleased]` in the CHANGELOG.