### PR TITLE
fix(e2e): import the shared trustbase URL instead of the deleted testnet.json

### DIFF
--- a/tests/e2e/dm-manual.test.ts
+++ b/tests/e2e/dm-manual.test.ts
@@ -13,10 +13,12 @@ import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { DirectMessage } from '../../types';
+// One definition (env-overridable): three local copies all named the deleted v1
+// file, whose networkId 3 stopped matching `network: 'testnet'` at the cutover.
+import { TRUSTBASE_URL } from './support/staging';
 
 const rand = () => Math.random().toString(36).slice(2, 8);
 
-const TRUSTBASE_URL = 'https://raw.githubusercontent.com/unicitynetwork/unicity-ids/refs/heads/main/bft-trustbase.testnet.json';
 const DEFAULT_API_KEY = 'sk_06365a9c44654841a366068bcfc68986';
 
 // Timeout for waiting for DM (60 seconds)

--- a/tests/e2e/dm-nip17.test.ts
+++ b/tests/e2e/dm-nip17.test.ts
@@ -16,10 +16,12 @@ import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { DirectMessage } from '../../types';
+// One definition (env-overridable): three local copies all named the deleted v1
+// file, whose networkId 3 stopped matching `network: 'testnet'` at the cutover.
+import { TRUSTBASE_URL } from './support/staging';
 
 const rand = () => Math.random().toString(36).slice(2, 8);
 
-const TRUSTBASE_URL = 'https://raw.githubusercontent.com/unicitynetwork/unicity-ids/refs/heads/main/bft-trustbase.testnet.json';
 const DEFAULT_API_KEY = 'sk_06365a9c44654841a366068bcfc68986';
 
 function makeTempDirs(label: string) {

--- a/tests/e2e/wallet-clear.test.ts
+++ b/tests/e2e/wallet-clear.test.ts
@@ -22,10 +22,12 @@ import { STORAGE_KEYS_GLOBAL } from '../../constants';
 import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+// One definition (env-overridable): three local copies all named the deleted v1
+// file, whose networkId 3 stopped matching `network: 'testnet'` at the cutover.
+import { TRUSTBASE_URL } from './support/staging';
 
 const rand = () => Math.random().toString(36).slice(2, 8);
 
-const TRUSTBASE_URL = 'https://raw.githubusercontent.com/unicitynetwork/unicity-ids/refs/heads/main/bft-trustbase.testnet.json';
 const DEFAULT_API_KEY = 'sk_06365a9c44654841a366068bcfc68986';
 
 function makeTempDirs(label: string) {


### PR DESCRIPTION
`bft-trustbase.testnet.json` was deleted upstream as obsolete. Three e2e suites hardcoded its raw URL and `throw` on a non-200, so each now fails at setup with `Failed to download trustbase: 404`.

The deletion only **revealed** the defect. That file declared `networkId 3` (the retired v1 testnet) while all three suites pass `network: 'testnet'` — which since #765 aliases testnet2, `networkId 4`. The oracle derives the engine's network id from the file at `trustBasePath`, so the engine was being built for a network the gateway does not serve.

`tests/e2e/support/staging.ts` already exports the correct, env-overridable `TRUSTBASE_URL` (testnet2, `networkId 4`). Importing it collapses four copies of the constant into one and takes the network mismatch with it.

Verified: the new URL returns 200 with `networkId: 4`; the old one returns 404 cache-busted. `typecheck:tests` and `lint` clean. These suites run in no CI job, so nothing went red.

Closes #775